### PR TITLE
Add built-in layout definitions

### DIFF
--- a/src/agent_slides/model/__init__.py
+++ b/src/agent_slides/model/__init__.py
@@ -1,5 +1,6 @@
 """Scene graph model package."""
 
+from .layouts import get_layout, list_layouts
 from .types import (
     ComputedNode,
     Counters,
@@ -30,4 +31,6 @@ __all__ = [
     "ThemeColors",
     "ThemeFonts",
     "ThemeSpacing",
+    "get_layout",
+    "list_layouts",
 ]

--- a/src/agent_slides/model/layouts.py
+++ b/src/agent_slides/model/layouts.py
@@ -1,0 +1,135 @@
+"""Built-in layout definitions for v0."""
+
+from __future__ import annotations
+
+from agent_slides.errors import AgentSlidesError, INVALID_LAYOUT
+from agent_slides.model.types import GridDef, LayoutDef, SlotDef, TextFitting
+
+SLIDE_WIDTH_PT = 720.0
+SLIDE_HEIGHT_PT = 540.0
+DEFAULT_MARGIN_PT = 60.0
+DEFAULT_GUTTER_PT = 20.0
+
+DEFAULT_TEXT_FITTING = {
+    "heading": TextFitting(default_size=32.0, min_size=24.0),
+    "body": TextFitting(default_size=18.0, min_size=10.0),
+}
+
+
+def _grid(*, columns: int, rows: int, row_heights: list[float], col_widths: list[float]) -> GridDef:
+    return GridDef(
+        columns=columns,
+        rows=rows,
+        row_heights=row_heights,
+        col_widths=col_widths,
+        margin=DEFAULT_MARGIN_PT,
+        gutter=DEFAULT_GUTTER_PT,
+    )
+
+
+def _layout(
+    *,
+    name: str,
+    slots: dict[str, SlotDef],
+    grid: GridDef,
+    text_fitting: dict[str, TextFitting] | None = None,
+) -> LayoutDef:
+    return LayoutDef(
+        name=name,
+        slots=slots,
+        grid=grid,
+        text_fitting=text_fitting or {},
+    )
+
+
+LAYOUTS: dict[str, LayoutDef] = {
+    "blank": _layout(
+        name="blank",
+        slots={},
+        grid=_grid(columns=1, rows=1, row_heights=[1.0], col_widths=[1.0]),
+    ),
+    "comparison": _layout(
+        name="comparison",
+        slots={
+            "title": SlotDef(grid_row=1, grid_col=[1, 2], role="heading"),
+            "left_header": SlotDef(grid_row=2, grid_col=1, role="heading"),
+            "left_body": SlotDef(grid_row=3, grid_col=1, role="body"),
+            "right_header": SlotDef(grid_row=2, grid_col=2, role="heading"),
+            "right_body": SlotDef(grid_row=3, grid_col=2, role="body"),
+        },
+        grid=_grid(columns=2, rows=3, row_heights=[0.12, 0.18, 0.70], col_widths=[0.5, 0.5]),
+        text_fitting=DEFAULT_TEXT_FITTING,
+    ),
+    "quote": _layout(
+        name="quote",
+        slots={
+            "quote": SlotDef(grid_row=1, grid_col=1, role="quote"),
+            "attribution": SlotDef(grid_row=2, grid_col=1, role="attribution"),
+        },
+        grid=_grid(columns=1, rows=2, row_heights=[0.70, 0.30], col_widths=[1.0]),
+        text_fitting={
+            "quote": TextFitting(default_size=28.0, min_size=20.0),
+            "attribution": TextFitting(default_size=16.0, min_size=12.0),
+        },
+    ),
+    "three_col": _layout(
+        name="three_col",
+        slots={
+            "title": SlotDef(grid_row=1, grid_col=[1, 2, 3], role="heading"),
+            "col1": SlotDef(grid_row=2, grid_col=1, role="body"),
+            "col2": SlotDef(grid_row=2, grid_col=2, role="body"),
+            "col3": SlotDef(grid_row=2, grid_col=3, role="body"),
+        },
+        grid=_grid(
+            columns=3,
+            rows=2,
+            row_heights=[0.12, 0.88],
+            col_widths=[1.0 / 3.0, 1.0 / 3.0, 1.0 / 3.0],
+        ),
+        text_fitting=DEFAULT_TEXT_FITTING,
+    ),
+    "title": _layout(
+        name="title",
+        slots={
+            "title": SlotDef(grid_row=1, grid_col=1, role="heading"),
+            "subtitle": SlotDef(grid_row=2, grid_col=1, role="body"),
+        },
+        grid=_grid(columns=1, rows=2, row_heights=[0.40, 0.60], col_widths=[1.0]),
+        text_fitting=DEFAULT_TEXT_FITTING,
+    ),
+    "title_content": _layout(
+        name="title_content",
+        slots={
+            "title": SlotDef(grid_row=1, grid_col=1, role="heading"),
+            "body": SlotDef(grid_row=2, grid_col=1, role="body"),
+        },
+        grid=_grid(columns=1, rows=2, row_heights=[0.12, 0.88], col_widths=[1.0]),
+        text_fitting=DEFAULT_TEXT_FITTING,
+    ),
+    "two_col": _layout(
+        name="two_col",
+        slots={
+            "title": SlotDef(grid_row=1, grid_col=[1, 2], role="heading"),
+            "col1": SlotDef(grid_row=2, grid_col=1, role="body"),
+            "col2": SlotDef(grid_row=2, grid_col=2, role="body"),
+        },
+        grid=_grid(columns=2, rows=2, row_heights=[0.12, 0.88], col_widths=[0.5, 0.5]),
+        text_fitting=DEFAULT_TEXT_FITTING,
+    ),
+}
+
+
+def get_layout(name: str) -> LayoutDef:
+    """Return a built-in layout definition by name."""
+
+    try:
+        return LAYOUTS[name]
+    except KeyError as exc:
+        available = ", ".join(list_layouts())
+        raise AgentSlidesError(INVALID_LAYOUT, f"Unknown layout '{name}'. Available layouts: {available}") from exc
+
+
+def list_layouts() -> list[str]:
+    """Return the sorted list of available built-in layouts."""
+
+    return sorted(LAYOUTS)

--- a/src/agent_slides/model/types.py
+++ b/src/agent_slides/model/types.py
@@ -118,6 +118,15 @@ class LayoutDef(AgentSlidesModel):
     grid: GridDef
     text_fitting: dict[str, TextFitting]
 
+    @model_validator(mode="after")
+    def validate_text_fitting(self) -> LayoutDef:
+        used_roles = {slot.role for slot in self.slots.values()}
+        missing_roles = used_roles.difference(self.text_fitting)
+        if missing_roles:
+            missing = ", ".join(sorted(missing_roles))
+            raise ValueError(f"text_fitting missing roles: {missing}")
+        return self
+
 
 class Counters(AgentSlidesModel):
     slides: int = 0

--- a/tests/test_layouts.py
+++ b/tests/test_layouts.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from math import isclose
+
+import pytest
+
+from agent_slides.errors import AgentSlidesError, INVALID_LAYOUT
+from agent_slides.model.layouts import get_layout, list_layouts
+
+
+EXPECTED_LAYOUTS = [
+    "blank",
+    "comparison",
+    "quote",
+    "three_col",
+    "title",
+    "title_content",
+    "two_col",
+]
+
+EXPECTED_SLOTS = {
+    "blank": {},
+    "comparison": {
+        "title": "heading",
+        "left_header": "heading",
+        "left_body": "body",
+        "right_header": "heading",
+        "right_body": "body",
+    },
+    "quote": {
+        "quote": "quote",
+        "attribution": "attribution",
+    },
+    "three_col": {
+        "title": "heading",
+        "col1": "body",
+        "col2": "body",
+        "col3": "body",
+    },
+    "title": {
+        "title": "heading",
+        "subtitle": "body",
+    },
+    "title_content": {
+        "title": "heading",
+        "body": "body",
+    },
+    "two_col": {
+        "title": "heading",
+        "col1": "body",
+        "col2": "body",
+    },
+}
+
+
+def test_list_layouts_returns_sorted_names() -> None:
+    assert list_layouts() == EXPECTED_LAYOUTS
+
+
+@pytest.mark.parametrize("name", EXPECTED_LAYOUTS)
+def test_get_layout_returns_all_builtins(name: str) -> None:
+    layout = get_layout(name)
+
+    assert layout.name == name
+    assert {slot_name: slot.role for slot_name, slot in layout.slots.items()} == EXPECTED_SLOTS[name]
+
+
+def test_get_layout_raises_invalid_layout_error_for_unknown_name() -> None:
+    with pytest.raises(AgentSlidesError) as exc_info:
+        get_layout("invalid")
+
+    assert exc_info.value.code == INVALID_LAYOUT
+    assert "invalid" in str(exc_info.value)
+    for layout_name in EXPECTED_LAYOUTS:
+        assert layout_name in str(exc_info.value)
+
+
+@pytest.mark.parametrize("name", EXPECTED_LAYOUTS)
+def test_all_layout_grids_and_text_rules_are_valid(name: str) -> None:
+    layout = get_layout(name)
+
+    assert layout.grid.rows == len(layout.grid.row_heights)
+    assert layout.grid.columns == len(layout.grid.col_widths)
+    assert isclose(sum(layout.grid.row_heights), 1.0, rel_tol=0.0, abs_tol=1e-9)
+    assert isclose(sum(layout.grid.col_widths), 1.0, rel_tol=0.0, abs_tol=1e-9)
+
+    for slot in layout.slots.values():
+        assert slot.role in layout.text_fitting
+
+
+def test_multi_column_titles_span_all_columns() -> None:
+    assert get_layout("two_col").slots["title"].grid_col == [1, 2]
+    assert get_layout("three_col").slots["title"].grid_col == [1, 2, 3]
+    assert get_layout("comparison").slots["title"].grid_col == [1, 2]
+
+
+def test_quote_layout_uses_custom_text_fitting() -> None:
+    layout = get_layout("quote")
+
+    assert layout.text_fitting["quote"].default_size == 28.0
+    assert layout.text_fitting["quote"].min_size == 20.0
+    assert layout.text_fitting["attribution"].default_size == 16.0
+    assert layout.text_fitting["attribution"].min_size == 12.0


### PR DESCRIPTION
## Summary
- add the 7 built-in v0 layouts with slot, grid, and text-fitting metadata
- expose `get_layout()` and `list_layouts()` for layout lookup
- expand the model types and tests needed to validate layout definitions against the current project baseline

## Validation
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/test_layouts.py -v`
- `UV_CACHE_DIR=.uv-cache uv run pytest -v`

Closes #3