### PR TITLE
Implement text fitting heuristic

### DIFF
--- a/src/agent_slides/engine/__init__.py
+++ b/src/agent_slides/engine/__init__.py
@@ -1,1 +1,5 @@
 """Layout and render engine package."""
+
+from agent_slides.engine.text_fit import fit_text
+
+__all__ = ["fit_text"]

--- a/src/agent_slides/engine/text_fit.py
+++ b/src/agent_slides/engine/text_fit.py
@@ -1,0 +1,58 @@
+"""Text fitting heuristics for bounded text slots."""
+
+from __future__ import annotations
+
+from math import ceil
+
+AVG_CHAR_WIDTH_FACTOR = 0.6
+LINE_HEIGHT_FACTOR = 1.2
+SHRINK_STEP_PT = 2.0
+
+
+def fit_text(
+    text: str,
+    width: float,
+    height: float,
+    default_size: float,
+    min_size: float = 10.0,
+) -> tuple[float, bool]:
+    """Estimate a font size that fits text into a bounded area."""
+    if width <= 0 or height <= 0:
+        return min_size, True
+
+    if text == "":
+        return default_size, False
+
+    if len(text) == 1:
+        return default_size, False
+
+    font_size = default_size
+
+    while font_size > min_size:
+        if _fits(text, width, height, font_size):
+            return font_size, False
+
+        font_size -= SHRINK_STEP_PT
+
+    if _fits(text, width, height, min_size):
+        return min_size, False
+
+    return min_size, True
+
+
+def _fits(text: str, width: float, height: float, font_size: float) -> bool:
+    avg_char_width = AVG_CHAR_WIDTH_FACTOR * font_size
+
+    if avg_char_width <= 0:
+        return False
+
+    chars_per_line = width / avg_char_width
+
+    # Treat sub-character widths as one character per line to avoid division blowups.
+    if chars_per_line < 1:
+        lines = len(text)
+    else:
+        lines = ceil(len(text) / chars_per_line)
+
+    estimated_height = lines * font_size * LINE_HEIGHT_FACTOR
+    return estimated_height <= height

--- a/tests/test_text_fit.py
+++ b/tests/test_text_fit.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from agent_slides.engine.text_fit import fit_text
+
+
+def test_short_text_fits_at_default_size() -> None:
+    assert fit_text("Hello world", width=200, height=80, default_size=32) == (32, False)
+
+
+def test_medium_text_shrinks_until_it_fits() -> None:
+    font_size, overflowed = fit_text("A" * 60, width=180, height=100, default_size=32)
+
+    assert font_size == 20
+    assert overflowed is False
+
+
+def test_long_text_overflows_at_min_size() -> None:
+    assert fit_text("A" * 500, width=120, height=60, default_size=24) == (10.0, True)
+
+
+def test_empty_text_returns_default_size() -> None:
+    assert fit_text("", width=120, height=60, default_size=24) == (24, False)
+
+
+def test_single_character_returns_default_size() -> None:
+    assert fit_text("A", width=20, height=20, default_size=32) == (32, False)
+
+
+def test_very_long_text_shrinks_to_min_size_and_overflows() -> None:
+    assert fit_text("A" * 10_000, width=500, height=200, default_size=24) == (10.0, True)
+
+
+def test_zero_width_returns_min_size_with_overflow() -> None:
+    assert fit_text("Hello", width=0, height=60, default_size=24) == (10.0, True)
+
+
+def test_shrinking_happens_in_two_point_steps() -> None:
+    font_size, overflowed = fit_text("A" * 50, width=180, height=170, default_size=32)
+
+    assert font_size == 28
+    assert overflowed is False


### PR DESCRIPTION
## Summary
- add the bounded text fitting heuristic in `agent_slides.engine.text_fit`
- expose the engine entry point and cover default-fit, shrink, overflow, and edge-case behavior
- add focused pytest coverage for the issue acceptance cases, including 2pt shrink steps and 10K-character overflow

Closes #8

## Validation
- `UV_CACHE_DIR=/tmp/agent-slides-uv-cache uv run pytest tests/test_text_fit.py -v`
- `UV_CACHE_DIR=/tmp/agent-slides-uv-cache uv run pytest -v`
