### PR TITLE
Split computed deck cache into deck.computed.json

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# Architecture Decisions
+
+## Computed Layout Persistence
+
+Decision date: 2026-03-28
+
+Decision: persist derived layout data in `deck.computed.json`, not in `deck.json`.
+
+### Evaluation
+
+#### Option A: Separate `deck.computed.json`
+
+- Pros:
+  - Keeps `deck.json` as the source-of-truth model, which removes diff noise and revision churn from derived positions and resolved styles.
+  - Gives Milestone 0.3 preview a clean watch boundary: it can watch `deck.computed.json` for "reflow finished" events and then read both files at matching revisions.
+  - Preserves the current architecture where preview can consume computed data without embedding the reflow engine.
+- Cons:
+  - Writing two files is not transactionally atomic across the filesystem.
+  - The I/O layer has to manage a second schema and stale-cache handling.
+
+Mitigation:
+
+- The engine writes `deck.json` first and `deck.computed.json` second. Preview should watch the computed sidecar, because its update is the signal that the source deck write has already completed.
+- `read_deck()` ignores a computed sidecar whose `deck_id` or `revision` does not match the source deck, so stale cache never becomes source-of-truth.
+
+#### Option B: Keep computed in `deck.json`
+
+- Pros:
+  - One file, simpler persistence.
+  - No coordination between source and cache files.
+- Cons:
+  - Derived state keeps polluting source diffs.
+  - Preview would need field-level change filtering inside a mixed source/cache document.
+  - Keeps conceptual ownership muddy right before the first external consumer of computed data ships.
+
+#### Option C: Compute on demand only
+
+- Pros:
+  - Eliminates cache persistence and staleness entirely.
+  - Only one persisted file remains.
+- Cons:
+  - Forces the preview server to depend on and execute the reflow engine.
+  - Adds latency to preview updates and couples Milestone 0.3 preview architecture to engine internals earlier than planned.
+  - Makes preview less of a thin consumer and more of a second execution environment.
+
+### Outcome
+
+Option A is the best fit for the approved v0 architecture. It preserves the "sidecar JSON is source of truth" rule for authoring data, keeps computed data available to the preview server as a persisted cache, and gives the preview milestone a cleaner file-watching model without forcing on-demand engine execution.

--- a/src/agent_slides/commands/build.py
+++ b/src/agent_slides/commands/build.py
@@ -8,7 +8,7 @@ from pathlib import Path
 import click
 
 from agent_slides.engine.reflow import reflow_deck
-from agent_slides.io import read_deck, write_pptx
+from agent_slides.io import read_deck, write_computed_deck, write_pptx
 
 
 @click.command("build")
@@ -25,6 +25,7 @@ def build_command(path: Path, output_path: Path) -> None:
 
     deck = read_deck(str(path))
     reflow_deck(deck)
+    write_computed_deck(str(path), deck)
     write_pptx(deck, str(output_path))
     payload = {
         "ok": True,

--- a/src/agent_slides/io/__init__.py
+++ b/src/agent_slides/io/__init__.py
@@ -1,13 +1,24 @@
 """I/O helpers package."""
 
-from agent_slides.io.sidecar import init_deck, mutate_deck, read_deck, write_deck
+from agent_slides.io.sidecar import (
+    computed_sidecar_path,
+    init_deck,
+    mutate_deck,
+    read_computed_deck,
+    read_deck,
+    write_computed_deck,
+    write_deck,
+)
 from agent_slides.io.pptx_writer import render_text_node, write_pptx
 
 __all__ = [
+    "computed_sidecar_path",
     "init_deck",
     "mutate_deck",
+    "read_computed_deck",
     "read_deck",
     "render_text_node",
+    "write_computed_deck",
     "write_deck",
     "write_pptx",
 ]

--- a/src/agent_slides/io/sidecar.py
+++ b/src/agent_slides/io/sidecar.py
@@ -17,7 +17,7 @@ from agent_slides.errors import (
     REVISION_CONFLICT,
     SCHEMA_ERROR,
 )
-from agent_slides.model import Deck
+from agent_slides.model import ComputedDeck, Deck
 
 T = TypeVar("T")
 
@@ -33,46 +33,140 @@ def _raise_write_error(path: Path, exc: OSError) -> None:
     ) from exc
 
 
-def _write_atomic(path: Path, deck: Deck) -> None:
+def _stage_atomic_write(path: Path, payload: str) -> Path:
     tmp_path = Path(f"{path}.tmp")
-    payload = f"{deck.model_dump_json(indent=2)}\n"
+    tmp_path.write_text(payload, encoding="utf-8")
+    return tmp_path
 
-    try:
-        tmp_path.write_text(payload, encoding="utf-8")
-        os.rename(tmp_path, path)
-    except OSError as exc:
+
+def _cleanup_tmp_files(paths: list[Path]) -> None:
+    for path in paths:
         try:
-            tmp_path.unlink(missing_ok=True)
+            path.unlink(missing_ok=True)
         except OSError:
             pass
+
+
+def _commit_staged_writes(staged_paths: list[tuple[Path, Path]]) -> None:
+    written_tmp_paths: list[Path] = []
+
+    try:
+        for tmp_path, path in staged_paths:
+            written_tmp_paths.append(tmp_path)
+            os.rename(tmp_path, path)
+    except OSError as exc:
+        _cleanup_tmp_files(written_tmp_paths)
+        pending = [tmp_path for tmp_path, _ in staged_paths if tmp_path not in written_tmp_paths]
+        _cleanup_tmp_files(pending)
         _raise_write_error(path, exc)
+
+
+def _serialize_deck_payload(deck: Deck) -> str:
+    payload = deck.model_dump(mode="json", by_alias=True)
+    for slide in payload["slides"]:
+        slide.pop("computed", None)
+    return f"{json.dumps(payload, indent=2)}\n"
+
+
+def _serialize_computed_payload(deck: Deck) -> str:
+    return f"{ComputedDeck.from_deck(deck).model_dump_json(indent=2)}\n"
+
+
+def _write_bundle_atomic(path: Path, deck: Deck) -> None:
+    computed_path = computed_sidecar_path(path)
+    staged_paths: list[tuple[Path, Path]] = []
+
+    try:
+        staged_paths.append((_stage_atomic_write(path, _serialize_deck_payload(deck)), path))
+        staged_paths.append(
+            (_stage_atomic_write(computed_path, _serialize_computed_payload(deck)), computed_path)
+        )
+    except OSError as exc:
+        _cleanup_tmp_files([tmp_path for tmp_path, _ in staged_paths])
+        _raise_write_error(path, exc)
+
+    _commit_staged_writes(staged_paths)
+
+
+def computed_sidecar_path(path: str | Path) -> Path:
+    deck_path = Path(path)
+    return deck_path.with_name(f"{deck_path.stem}.computed{deck_path.suffix}")
+
+
+def _parse_json_file(path: Path) -> object:
+    try:
+        payload = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise AgentSlidesError(FILE_NOT_FOUND, f"Deck file not found: {path}") from exc
+
+    try:
+        return json.loads(payload)
+    except json.JSONDecodeError as exc:
+        raise AgentSlidesError(
+            SCHEMA_ERROR,
+            f"Invalid JSON in {path}: {exc.msg} at line {exc.lineno} column {exc.colno}",
+        ) from exc
+
+
+def _read_computed_deck_optional(path: Path) -> ComputedDeck | None:
+    try:
+        raw = _parse_json_file(path)
+    except AgentSlidesError as exc:
+        if exc.code == FILE_NOT_FOUND:
+            return None
+        raise
+
+    try:
+        return ComputedDeck.model_validate(raw)
+    except ValidationError as exc:
+        raise AgentSlidesError(
+            SCHEMA_ERROR,
+            f"Invalid computed deck structure in {path}: {_format_validation_error(exc)}",
+        ) from exc
 
 
 def read_deck(path: str) -> Deck:
     """Load, parse, and validate a sidecar deck file."""
 
     deck_path = Path(path)
+    raw = _parse_json_file(deck_path)
 
     try:
-        payload = deck_path.read_text(encoding="utf-8")
-    except FileNotFoundError as exc:
-        raise AgentSlidesError(FILE_NOT_FOUND, f"Deck file not found: {deck_path}") from exc
-
-    try:
-        raw = json.loads(payload)
-    except json.JSONDecodeError as exc:
-        raise AgentSlidesError(
-            SCHEMA_ERROR,
-            f"Invalid JSON in {deck_path}: {exc.msg} at line {exc.lineno} column {exc.colno}",
-        ) from exc
-
-    try:
-        return Deck.model_validate(raw)
+        deck = Deck.model_validate(raw)
     except ValidationError as exc:
         raise AgentSlidesError(
             SCHEMA_ERROR,
             f"Invalid deck structure in {deck_path}: {_format_validation_error(exc)}",
         ) from exc
+
+    computed_deck = _read_computed_deck_optional(computed_sidecar_path(deck_path))
+    if computed_deck is not None:
+        computed_deck.apply_to_deck(deck)
+
+    return deck
+
+
+def read_computed_deck(path: str) -> ComputedDeck:
+    """Load, parse, and validate a computed deck sidecar."""
+
+    computed_path = computed_sidecar_path(path)
+    computed_deck = _read_computed_deck_optional(computed_path)
+    if computed_deck is None:
+        raise AgentSlidesError(FILE_NOT_FOUND, f"Deck file not found: {computed_path}")
+    return computed_deck
+
+
+def write_computed_deck(path: str, deck: Deck) -> None:
+    """Persist just the computed sidecar for an already-loaded deck."""
+
+    computed_path = computed_sidecar_path(path)
+
+    try:
+        staged = _stage_atomic_write(computed_path, _serialize_computed_payload(deck))
+    except OSError as exc:
+        _raise_write_error(computed_path, exc)
+
+    _commit_staged_writes([(staged, computed_path)])
 
 
 def write_deck(path: str, deck: Deck, expected_revision: int) -> None:
@@ -86,7 +180,7 @@ def write_deck(path: str, deck: Deck, expected_revision: int) -> None:
             f"Revision conflict for {deck_path}: expected {expected_revision}, found {current.revision}",
         )
 
-    _write_atomic(deck_path, deck)
+    _write_bundle_atomic(deck_path, deck)
 
 
 def mutate_deck(path: str, fn: Callable[[Deck], T]) -> tuple[Deck, T]:
@@ -116,5 +210,5 @@ def init_deck(path: str, theme: str, design_rules: str, force: bool) -> Deck:
         theme=theme,
         design_rules=design_rules,
     )
-    _write_atomic(deck_path, deck)
+    _write_bundle_atomic(deck_path, deck)
     return deck

--- a/src/agent_slides/model/__init__.py
+++ b/src/agent_slides/model/__init__.py
@@ -2,6 +2,8 @@
 
 from .types import (
     ComputedNode,
+    ComputedDeck,
+    ComputedSlide,
     Counters,
     Deck,
     GridDef,
@@ -21,6 +23,8 @@ from agent_slides.model.layouts import get_layout, list_layouts
 
 __all__ = [
     "ComputedNode",
+    "ComputedDeck",
+    "ComputedSlide",
     "Constraint",
     "Counters",
     "Deck",

--- a/src/agent_slides/model/types.py
+++ b/src/agent_slides/model/types.py
@@ -171,3 +171,43 @@ class Deck(AgentSlidesModel):
                 return slide
 
         raise AgentSlidesError(INVALID_SLIDE, f"Slide {ref!r} does not exist")
+
+
+class ComputedSlide(AgentSlidesModel):
+    slide_id: str
+    computed: dict[str, ComputedNode] = Field(default_factory=dict)
+
+
+class ComputedDeck(AgentSlidesModel):
+    version: int = 1
+    deck_id: str
+    revision: int = 0
+    slides: list[ComputedSlide] = Field(default_factory=list)
+
+    @classmethod
+    def from_deck(cls, deck: Deck) -> ComputedDeck:
+        return cls(
+            deck_id=deck.deck_id,
+            revision=deck.revision,
+            slides=[
+                ComputedSlide(
+                    slide_id=slide.slide_id,
+                    computed=slide.computed,
+                )
+                for slide in deck.slides
+            ],
+        )
+
+    def apply_to_deck(self, deck: Deck) -> None:
+        for slide in deck.slides:
+            slide.computed = {}
+
+        if self.deck_id != deck.deck_id or self.revision != deck.revision:
+            return
+
+        slides_by_id = {slide.slide_id: slide for slide in deck.slides}
+        for computed_slide in self.slides:
+            slide = slides_by_id.get(computed_slide.slide_id)
+            if slide is None:
+                continue
+            slide.computed = dict(computed_slide.computed)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -18,7 +18,7 @@ from agent_slides.errors import (
     THEME_NOT_FOUND,
     UNBOUND_NODES,
 )
-from agent_slides.io import init_deck, read_deck
+from agent_slides.io import computed_sidecar_path, init_deck, read_computed_deck, read_deck, write_computed_deck
 from agent_slides.model import Counters, Deck, Node, Slide, get_layout, list_layouts
 from agent_slides.model.design_rules import load_design_rules
 from agent_slides.model.types import ComputedNode
@@ -29,7 +29,11 @@ def read_payload(path: Path) -> dict[str, object]:
 
 
 def write_deck(path: Path, deck: Deck) -> None:
-    path.write_text(f"{deck.model_dump_json(indent=2)}\n", encoding="utf-8")
+    payload = json.loads(deck.model_dump_json(by_alias=True))
+    for slide in payload["slides"]:
+        slide.pop("computed", None)
+    path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
+    write_computed_deck(str(path), deck)
 
 
 def build_slide(slide_id: str, layout: str, slots: list[str], *, start_node: int = 1) -> Slide:
@@ -156,6 +160,7 @@ def make_overflow_deck() -> Deck:
 
 def test_init_creates_valid_deck_file_and_reports_success_json(tmp_path: Path) -> None:
     deck_path = tmp_path / "deck.json"
+    computed_path = computed_sidecar_path(deck_path)
 
     result = invoke_cli(["init", str(deck_path)])
 
@@ -176,6 +181,8 @@ def test_init_creates_valid_deck_file_and_reports_success_json(tmp_path: Path) -
     assert payload["design_rules"] == "default"
     assert payload["version"] == 1
     assert payload["_counters"] == {"slides": 0, "nodes": 0}
+    assert computed_path.exists()
+    assert read_computed_deck(str(deck_path)).slides == []
 
 
 def test_init_applies_explicit_theme_and_rules_options(tmp_path: Path) -> None:
@@ -188,6 +195,7 @@ def test_init_applies_explicit_theme_and_rules_options(tmp_path: Path) -> None:
 
     assert payload["theme"] == "default"
     assert payload["design_rules"] == "default"
+    assert computed_sidecar_path(deck_path).exists()
 
 
 def test_init_returns_file_exists_error_when_target_exists(tmp_path: Path) -> None:
@@ -223,6 +231,7 @@ def test_init_force_overwrites_existing_file(tmp_path: Path) -> None:
     assert payload["theme"] == "default"
     assert payload["design_rules"] == "default"
     assert payload["deck_id"] != "old"
+    assert computed_sidecar_path(deck_path).exists()
 
 
 def test_init_returns_theme_validation_error_for_invalid_theme(tmp_path: Path) -> None:
@@ -664,6 +673,7 @@ def test_build_command_creates_valid_pptx_and_reports_slide_count(tmp_path: Path
     }
     presentation = Presentation(output_path)
     assert len(presentation.slides) == 2
+    assert read_computed_deck(str(deck_path)).revision == make_clean_deck().revision
 
 
 def test_build_command_reports_missing_deck_as_file_not_found(tmp_path: Path) -> None:
@@ -724,6 +734,7 @@ def test_info_command_dumps_indented_deck_json(tmp_path: Path) -> None:
     assert result.stderr == ""
     assert result.output == f"{deck.model_dump_json(by_alias=True, indent=2)}\n"
     assert result.output.startswith("{\n  ")
+    assert "computed" not in read_payload(deck_path)["slides"][0]
 
 
 def test_info_command_reports_missing_deck_as_file_not_found(tmp_path: Path) -> None:

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -15,7 +15,8 @@ from agent_slides.errors import (
     SCHEMA_ERROR,
 )
 from agent_slides.io.sidecar import init_deck, mutate_deck, read_deck, write_deck
-from agent_slides.model import ComputedNode, Counters, Deck, Node, Slide
+from agent_slides.io.sidecar import computed_sidecar_path, read_computed_deck, write_computed_deck
+from agent_slides.model import ComputedDeck, ComputedNode, Counters, Deck, Node, Slide
 
 
 def build_deck(*, revision: int = 2) -> Deck:
@@ -103,6 +104,7 @@ def test_write_deck_uses_atomic_temp_file_and_rename(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     deck_path = tmp_path / "deck.json"
+    computed_path = computed_sidecar_path(deck_path)
     deck = build_deck()
     write_raw_deck(deck_path, deck)
 
@@ -118,7 +120,10 @@ def test_write_deck_uses_atomic_temp_file_and_rename(
     updated = build_deck(revision=3)
     write_deck(str(deck_path), updated, expected_revision=2)
 
-    assert renamed_paths == [(f"{deck_path}.tmp", str(deck_path))]
+    assert renamed_paths == [
+        (f"{deck_path}.tmp", str(deck_path)),
+        (f"{computed_path}.tmp", str(computed_path)),
+    ]
     assert read_deck(str(deck_path)).revision == 3
 
 
@@ -173,6 +178,7 @@ def test_mutate_deck_runs_full_pipeline(tmp_path: Path, monkeypatch: pytest.Monk
     assert updated_deck.theme == "updated"
     assert reflow_revisions == [3]
     assert read_deck(str(deck_path)).theme == "updated"
+    assert computed_sidecar_path(deck_path).exists()
 
 
 def test_mutate_deck_does_not_write_if_mutation_raises(tmp_path: Path) -> None:
@@ -193,16 +199,19 @@ def test_mutate_deck_does_not_write_if_mutation_raises(tmp_path: Path) -> None:
 
 def test_init_deck_creates_new_file_with_defaults(tmp_path: Path) -> None:
     deck_path = tmp_path / "deck.json"
+    computed_path = computed_sidecar_path(deck_path)
 
     deck = init_deck(str(deck_path), theme="modern", design_rules="default", force=False)
 
     assert deck_path.exists()
+    assert computed_path.exists()
     assert deck.revision == 0
     assert deck.theme == "modern"
     assert deck.design_rules == "default"
     assert deck.slides == []
     assert deck.counters == Counters()
     assert UUID(deck.deck_id)
+    assert read_computed_deck(str(deck_path)) == ComputedDeck(deck_id=deck.deck_id)
 
 
 def test_init_deck_existing_file_without_force_raises(tmp_path: Path) -> None:
@@ -226,6 +235,7 @@ def test_init_deck_force_overwrites_existing_file(tmp_path: Path) -> None:
     assert loaded.design_rules == "new-rules"
     assert loaded.revision == 0
     assert loaded.slides == []
+    assert computed_sidecar_path(deck_path).exists()
 
 
 def test_sidecar_round_trip_preserves_all_fields_and_counters_alias(tmp_path: Path) -> None:
@@ -240,4 +250,35 @@ def test_sidecar_round_trip_preserves_all_fields_and_counters_alias(tmp_path: Pa
     payload = json.loads(deck_path.read_text(encoding="utf-8"))
 
     assert payload["_counters"] == {"slides": 1, "nodes": 1}
+    assert "computed" not in payload["slides"][0]
     assert restored == original
+
+
+def test_read_deck_prefers_computed_sidecar_when_present(tmp_path: Path) -> None:
+    deck_path = tmp_path / "deck.json"
+    write_raw_deck(deck_path, build_deck(revision=4))
+
+    deck = read_deck(str(deck_path))
+    deck.slides[0].computed["n-1"].font_size_pt = 16.0
+    write_deck(str(deck_path), deck, expected_revision=4)
+
+    loaded = read_deck(str(deck_path))
+
+    assert loaded.slides[0].computed["n-1"].font_size_pt == 16.0
+    assert "computed" not in json.loads(deck_path.read_text(encoding="utf-8"))["slides"][0]
+
+
+def test_read_deck_ignores_stale_computed_sidecar(tmp_path: Path) -> None:
+    deck_path = tmp_path / "deck.json"
+    deck = build_deck(revision=2)
+    write_raw_deck(deck_path, deck)
+    write_computed_deck(str(deck_path), deck)
+
+    updated_payload = json.loads(deck_path.read_text(encoding="utf-8"))
+    updated_payload["revision"] = 9
+    deck_path.write_text(f"{json.dumps(updated_payload, indent=2)}\n", encoding="utf-8")
+
+    loaded = read_deck(str(deck_path))
+
+    assert loaded.revision == 9
+    assert loaded.slides[0].computed == {}

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -6,7 +6,7 @@ import pytest
 from pydantic import ValidationError
 
 from agent_slides.errors import AgentSlidesError, INVALID_SLIDE
-from agent_slides.model.types import ComputedNode, Counters, Deck, Node, Slide
+from agent_slides.model.types import ComputedDeck, ComputedNode, Counters, Deck, Node, Slide
 
 
 def build_deck() -> Deck:
@@ -123,3 +123,18 @@ def test_computed_node_includes_resolved_style_fields() -> None:
     assert computed.color == "#111111"
     assert computed.bg_color == "#FAFAFA"
     assert computed.font_bold is False
+
+
+def test_computed_deck_round_trip_applies_only_matching_revision() -> None:
+    deck = build_deck()
+    computed = ComputedDeck.from_deck(deck)
+
+    deck.slides[0].computed = {}
+    computed.apply_to_deck(deck)
+
+    assert deck.slides[0].computed["n-1"].font_size_pt == 28.0
+
+    deck.bump_revision()
+    computed.apply_to_deck(deck)
+
+    assert deck.slides[0].computed == {}


### PR DESCRIPTION
## Summary
- move derived `computed` layout data out of `deck.json` into `deck.computed.json`
- hydrate runtime decks from the computed sidecar while keeping `deck.json` source-only
- document the option analysis and chosen design for preview-server consumers

## Testing
- `uv run pytest -v`

Closes #34