### PR TITLE
Add image node support to scene graph models

### DIFF
--- a/src/agent_slides/engine/reflow.py
+++ b/src/agent_slides/engine/reflow.py
@@ -83,6 +83,26 @@ def _reflow_slide(slide: Slide, layout_def: LayoutDef, theme: Theme, *, revision
 
         slot = layout_def.slots[node.slot_binding]
         x, y, width, height = _compute_slot_frame(layout_def, node.slot_binding, theme)
+        style = resolve_style(theme, slot.role)
+
+        if node.type == "image":
+            computed[node.node_id] = ComputedNode(
+                x=x,
+                y=y,
+                width=width,
+                height=height,
+                font_size_pt=0.0,
+                font_family=str(style["font_family"]),
+                color=str(style["color"]),
+                bg_color=theme.colors.background,
+                font_bold=False,
+                text_overflow=False,
+                revision=revision,
+                content_type="image",
+                image_fit=str(node.style_overrides.get("image_fit", "contain")),
+            )
+            continue
+
         fit_rules = _text_fit_rules(layout_def, node)
         font_size_pt, text_overflow = fit_text(
             text=node.content,
@@ -91,7 +111,6 @@ def _reflow_slide(slide: Slide, layout_def: LayoutDef, theme: Theme, *, revision
             default_size=fit_rules.default_size,
             min_size=fit_rules.min_size,
         )
-        style = resolve_style(theme, slot.role)
 
         computed[node.node_id] = ComputedNode(
             x=x,
@@ -105,6 +124,7 @@ def _reflow_slide(slide: Slide, layout_def: LayoutDef, theme: Theme, *, revision
             font_bold=bool(style["font_bold"]),
             text_overflow=text_overflow,
             revision=revision,
+            content_type="text",
         )
 
     slide.computed = computed

--- a/src/agent_slides/engine/validator.py
+++ b/src/agent_slides/engine/validator.py
@@ -60,26 +60,28 @@ def validate_slide(slide: Slide, rules: DesignRules) -> list[Constraint]:
 
     total_bullets = 0
     for node in slide.nodes:
-        total_bullets += _count_bullets(node.content)
+        if node.type == "text":
+            content = node.content if isinstance(node.content, NodeContent) else NodeContent.model_validate(node.content)
+            total_bullets += _count_bullets(content)
 
-        if node.slot_binding is not None:
-            word_count = _count_words(node.content)
-            if word_count > rules.content_limits.max_words_per_column:
-                constraints.append(
-                    Constraint(
-                        code=MAX_WORDS_PER_COLUMN_EXCEEDED,
-                        severity="warning",
-                        message=(
-                            f"Slot '{node.slot_binding}' has {word_count} words; "
-                            f"max is {rules.content_limits.max_words_per_column}."
-                        ),
-                        slide_id=slide.slide_id,
-                        node_id=node.node_id,
+            if node.slot_binding is not None:
+                word_count = _count_words(content)
+                if word_count > rules.content_limits.max_words_per_column:
+                    constraints.append(
+                        Constraint(
+                            code=MAX_WORDS_PER_COLUMN_EXCEEDED,
+                            severity="warning",
+                            message=(
+                                f"Slot '{node.slot_binding}' has {word_count} words; "
+                                f"max is {rules.content_limits.max_words_per_column}."
+                            ),
+                            slide_id=slide.slide_id,
+                            node_id=node.node_id,
+                        )
                     )
-                )
 
         computed = slide.computed.get(node.node_id)
-        if computed is None:
+        if computed is None or node.type != "text":
             continue
 
         if computed.text_overflow and isclose(

--- a/src/agent_slides/io/pptx_writer.py
+++ b/src/agent_slides/io/pptx_writer.py
@@ -108,6 +108,8 @@ def write_pptx(deck: Deck, output_path: str) -> None:
         for node in slide.nodes:
             if node.slot_binding is None:
                 continue
+            if node.type != "text":
+                continue
 
             computed = slide.computed.get(node.node_id)
             if computed is None:

--- a/src/agent_slides/model/themes.py
+++ b/src/agent_slides/model/themes.py
@@ -74,6 +74,12 @@ def resolve_style(theme: Theme, role: str) -> dict[str, str | bool]:
             "color": theme.colors.subtle_text,
             "font_bold": False,
         }
+    if role == "image":
+        return {
+            "font_family": theme.fonts.body,
+            "color": theme.colors.text,
+            "font_bold": False,
+        }
     raise AgentSlidesError(
         code=THEME_ROLE_NOT_FOUND,
         message=f"Role '{role}' is not defined by the theme system.",

--- a/src/agent_slides/model/types.py
+++ b/src/agent_slides/model/types.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import warnings
 from math import isclose
+from pathlib import Path
 from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
@@ -12,6 +14,12 @@ from agent_slides.errors import AgentSlidesError, INVALID_SLIDE
 STANDARD_SLIDE_WIDTH_PT = 720.0
 STANDARD_SLIDE_HEIGHT_PT = 540.0
 EMU_PER_POINT = 12_700
+MAX_IMAGE_SIZE_WARNING_BYTES = 5 * 1024 * 1024
+SUPPORTED_IMAGE_EXTENSIONS = frozenset({".png", ".jpg", ".jpeg", ".svg"})
+
+NodeType = Literal["text", "image"]
+ImageFit = Literal["contain", "cover", "stretch"]
+SlotRole = Literal["heading", "body", "quote", "attribution", "image"]
 
 
 class AgentSlidesModel(BaseModel):
@@ -36,6 +44,8 @@ class ComputedNode(AgentSlidesModel):
     font_bold: bool = False
     text_overflow: bool = False
     revision: int
+    content_type: NodeType = "text"
+    image_fit: ImageFit = "contain"
 
 
 class TextBlock(AgentSlidesModel):
@@ -87,9 +97,44 @@ class NodeContent(AgentSlidesModel):
 class Node(AgentSlidesModel):
     node_id: str
     slot_binding: str | None = None
-    type: Literal["text"]
-    content: NodeContent = Field(default_factory=NodeContent)
+    type: NodeType
+    content: NodeContent | str = Field(default_factory=NodeContent)
+    image_path: str | None = None
     style_overrides: dict[str, Any] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_content_by_type(cls, value: object) -> object:
+        if not isinstance(value, dict):
+            return value
+
+        data = dict(value)
+        node_type = data.get("type", "text")
+        content = data.get("content")
+
+        if node_type == "text":
+            data["content"] = NodeContent.model_validate(content)
+        elif node_type == "image" and (content is None or content == "") and data.get("image_path") is not None:
+            data["content"] = data["image_path"]
+
+        return data
+
+    @model_validator(mode="after")
+    def validate_node_type_specific_fields(self) -> Node:
+        if self.type == "text":
+            if not isinstance(self.content, NodeContent):
+                self.content = NodeContent.model_validate(self.content)
+            if self.image_path is not None:
+                raise ValueError("text nodes cannot define image_path")
+            return self
+
+        if not self.image_path:
+            raise ValueError("image nodes require image_path")
+        if not isinstance(self.content, str):
+            raise ValueError("image nodes must serialize content as a file path string")
+
+        self.image_path = _validate_and_resolve_image_path(self.image_path)
+        return self
 
 
 class Slide(AgentSlidesModel):
@@ -138,7 +183,7 @@ class Theme(AgentSlidesModel):
 class SlotDef(AgentSlidesModel):
     grid_row: int
     grid_col: int | list[int]
-    role: str
+    role: SlotRole
 
 
 class GridDef(AgentSlidesModel):
@@ -172,6 +217,36 @@ class LayoutDef(AgentSlidesModel):
     slots: dict[str, SlotDef]
     grid: GridDef
     text_fitting: dict[str, TextFitting]
+
+
+def _validate_and_resolve_image_path(value: str) -> str:
+    path = Path(value).expanduser()
+    resolved_path = path.resolve(strict=False)
+    suffix = resolved_path.suffix.lower()
+
+    if suffix not in SUPPORTED_IMAGE_EXTENSIONS:
+        supported = ", ".join(sorted(ext.lstrip(".") for ext in SUPPORTED_IMAGE_EXTENSIONS))
+        raise ValueError(f"image_path must use a supported image format: {supported}")
+    if not resolved_path.exists():
+        raise ValueError(f"image_path does not exist: {resolved_path}")
+    if not resolved_path.is_file():
+        raise ValueError(f"image_path must point to a file: {resolved_path}")
+
+    try:
+        with resolved_path.open("rb"):
+            pass
+    except OSError as exc:
+        raise ValueError(f"image_path is not readable: {resolved_path}") from exc
+
+    size_bytes = resolved_path.stat().st_size
+    if size_bytes > MAX_IMAGE_SIZE_WARNING_BYTES:
+        warnings.warn(
+            f"Image file '{resolved_path}' is larger than 5MB and may bloat output decks.",
+            UserWarning,
+            stacklevel=3,
+        )
+
+    return str(resolved_path)
 
 
 class Counters(AgentSlidesModel):

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from pathlib import Path
 
 import pytest
 from pydantic import ValidationError
@@ -109,9 +110,39 @@ def test_get_slide_raises_invalid_slide_error() -> None:
     assert exc_info.value.code == INVALID_SLIDE
 
 
-def test_text_only_nodes_reject_image_type() -> None:
-    with pytest.raises(ValidationError):
+def test_image_node_with_relative_path_is_valid(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    image_path = tmp_path / "photo.png"
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nimage-bytes")
+    monkeypatch.chdir(tmp_path)
+
+    node = Node(node_id="n-2", type="image", image_path="photo.png")
+
+    assert node.content == "photo.png"
+    assert node.image_path == str(image_path.resolve())
+
+
+def test_image_nodes_require_image_path() -> None:
+    with pytest.raises(ValidationError, match="image_path"):
         Node(node_id="n-2", type="image")
+
+
+def test_image_nodes_validate_file_existence_and_supported_format(tmp_path: Path) -> None:
+    with pytest.raises(ValidationError, match="does not exist"):
+        Node(node_id="n-2", type="image", image_path=str(tmp_path / "missing.png"))
+
+    unsupported_image = tmp_path / "logo.gif"
+    unsupported_image.write_bytes(b"GIF89a")
+
+    with pytest.raises(ValidationError, match="supported image format"):
+        Node(node_id="n-3", type="image", image_path=str(unsupported_image))
+
+
+def test_large_image_nodes_emit_warning(tmp_path: Path) -> None:
+    large_image = tmp_path / "large.png"
+    large_image.write_bytes(b"\x89PNG\r\n\x1a\n" + (b"0" * ((5 * 1024 * 1024) + 1)))
+
+    with pytest.warns(UserWarning, match="larger than 5MB"):
+        Node(node_id="n-2", type="image", image_path=str(large_image))
 
 
 def test_bump_revision_increments_by_one() -> None:
@@ -134,12 +165,26 @@ def test_computed_node_includes_resolved_style_fields() -> None:
         bg_color="#FAFAFA",
         font_bold=False,
         revision=1,
+        content_type="image",
     )
 
     assert computed.font_family == "IBM Plex Sans"
     assert computed.color == "#111111"
     assert computed.bg_color == "#FAFAFA"
     assert computed.font_bold is False
+    assert computed.content_type == "image"
+    assert computed.image_fit == "contain"
+
+
+def test_image_nodes_round_trip_through_json_serialization(tmp_path: Path) -> None:
+    image_path = tmp_path / "diagram.svg"
+    image_path.write_text("<svg xmlns='http://www.w3.org/2000/svg'></svg>", encoding="utf-8")
+
+    node = Node(node_id="n-9", type="image", image_path=str(image_path))
+    restored = Node.model_validate_json(node.model_dump_json())
+
+    assert restored == node
+    assert json.loads(node.model_dump_json())["image_path"] == str(image_path.resolve())
 
 
 def test_computed_deck_round_trip_applies_only_matching_revision() -> None:


### PR DESCRIPTION
## Summary
- extend the scene-graph models to accept `image` nodes with file-path validation and large-file warnings
- add `content_type` and `image_fit` to computed nodes and allow the `image` slot role in layout definitions
- keep existing text-only flows stable by skipping non-text validation/PPTX rendering and adding coverage for image serialization

Closes #45