### PR TITLE
Schema v2: add template_manifest field to Deck model

### DIFF
--- a/src/agent_slides/io/__init__.py
+++ b/src/agent_slides/io/__init__.py
@@ -6,6 +6,7 @@ from agent_slides.io.sidecar import (
     mutate_deck,
     read_computed_deck,
     read_deck,
+    resolve_manifest_path,
     write_computed_deck,
     write_deck,
 )
@@ -18,6 +19,7 @@ __all__ = [
     "read_computed_deck",
     "read_deck",
     "render_text_node",
+    "resolve_manifest_path",
     "write_computed_deck",
     "write_deck",
     "write_pptx",

--- a/src/agent_slides/io/sidecar.py
+++ b/src/agent_slides/io/sidecar.py
@@ -20,6 +20,7 @@ from agent_slides.errors import (
 from agent_slides.model import ComputedDeck, Deck
 
 T = TypeVar("T")
+CURRENT_DECK_VERSION = 2
 
 
 def _format_validation_error(exc: ValidationError) -> str:
@@ -108,6 +109,16 @@ def _parse_json_file(path: Path) -> object:
         ) from exc
 
 
+def _normalize_deck_payload(raw: object) -> object:
+    if not isinstance(raw, dict):
+        return raw
+
+    payload = dict(raw)
+    if payload.get("version") == 1:
+        payload["version"] = CURRENT_DECK_VERSION
+    return payload
+
+
 def _read_computed_deck_optional(path: Path) -> ComputedDeck | None:
     try:
         raw = _parse_json_file(path)
@@ -129,7 +140,7 @@ def read_deck(path: str) -> Deck:
     """Load, parse, and validate a sidecar deck file."""
 
     deck_path = Path(path)
-    raw = _parse_json_file(deck_path)
+    raw = _normalize_deck_payload(_parse_json_file(deck_path))
 
     try:
         deck = Deck.model_validate(raw)
@@ -144,6 +155,16 @@ def read_deck(path: str) -> Deck:
         computed_deck.apply_to_deck(deck)
 
     return deck
+
+
+def resolve_manifest_path(deck_path: str, deck: Deck) -> str | None:
+    """Resolve template_manifest to an absolute path relative to the deck file."""
+
+    if deck.template_manifest is None:
+        return None
+
+    deck_dir = os.path.dirname(os.path.abspath(deck_path))
+    return os.path.join(deck_dir, deck.template_manifest)
 
 
 def read_computed_deck(path: str) -> ComputedDeck:

--- a/src/agent_slides/model/types.py
+++ b/src/agent_slides/model/types.py
@@ -281,6 +281,7 @@ class Deck(AgentSlidesModel):
     revision: int = 0
     theme: str = "default"
     design_rules: str = "default"
+    template_manifest: str | None = None
     slides: list[Slide] = Field(default_factory=list)
     counters: Counters = Field(default_factory=Counters, alias="_counters")
 

--- a/tests/test_sidecar.py
+++ b/tests/test_sidecar.py
@@ -14,17 +14,26 @@ from agent_slides.errors import (
     REVISION_CONFLICT,
     SCHEMA_ERROR,
 )
-from agent_slides.io.sidecar import init_deck, mutate_deck, read_deck, write_deck
-from agent_slides.io.sidecar import computed_sidecar_path, read_computed_deck, write_computed_deck
+from agent_slides.io.sidecar import (
+    computed_sidecar_path,
+    init_deck,
+    mutate_deck,
+    read_computed_deck,
+    read_deck,
+    resolve_manifest_path,
+    write_computed_deck,
+    write_deck,
+)
 from agent_slides.model import ComputedDeck, ComputedNode, Counters, Deck, Node, Slide
 
 
-def build_deck(*, revision: int = 2) -> Deck:
+def build_deck(*, revision: int = 2, template_manifest: str | None = None) -> Deck:
     return Deck(
         deck_id="deck-1",
         revision=revision,
         theme="classic",
         design_rules="strict",
+        template_manifest=template_manifest,
         slides=[
             Slide(
                 slide_id="s-1",
@@ -100,7 +109,7 @@ def test_read_deck_wrong_structure_raises_schema_error_with_details(tmp_path: Pa
     assert "slides" in exc_info.value.message
 
 
-def test_read_deck_accepts_legacy_string_content_and_version_one(tmp_path: Path) -> None:
+def test_read_deck_upgrades_legacy_string_content_and_version_one(tmp_path: Path) -> None:
     deck_path = tmp_path / "deck.json"
     deck_path.write_text(
         json.dumps(
@@ -132,10 +141,21 @@ def test_read_deck_accepts_legacy_string_content_and_version_one(tmp_path: Path)
 
     deck = read_deck(str(deck_path))
 
-    assert deck.version == 1
+    assert deck.version == 2
+    assert deck.template_manifest is None
     assert deck.slides[0].nodes[0].content.model_dump(mode="json") == {
         "blocks": [{"type": "paragraph", "text": "Legacy title", "level": 0}]
     }
+
+
+def test_read_deck_loads_v2_template_manifest(tmp_path: Path) -> None:
+    deck_path = tmp_path / "deck.json"
+    write_raw_deck(deck_path, build_deck(template_manifest="templates/demo/manifest.json"))
+
+    deck = read_deck(str(deck_path))
+
+    assert deck.version == 2
+    assert deck.template_manifest == "templates/demo/manifest.json"
 
 
 def test_write_deck_uses_atomic_temp_file_and_rename(
@@ -278,7 +298,7 @@ def test_init_deck_force_overwrites_existing_file(tmp_path: Path) -> None:
 
 def test_sidecar_round_trip_preserves_all_fields_and_counters_alias(tmp_path: Path) -> None:
     deck_path = tmp_path / "deck.json"
-    original = build_deck(revision=7)
+    original = build_deck(revision=7, template_manifest="templates/demo/manifest.json")
     write_raw_deck(deck_path, original)
 
     updated = read_deck(str(deck_path))
@@ -288,8 +308,25 @@ def test_sidecar_round_trip_preserves_all_fields_and_counters_alias(tmp_path: Pa
     payload = json.loads(deck_path.read_text(encoding="utf-8"))
 
     assert payload["_counters"] == {"slides": 1, "nodes": 1}
+    assert payload["template_manifest"] == "templates/demo/manifest.json"
     assert "computed" not in payload["slides"][0]
     assert restored == original
+
+
+def test_resolve_manifest_path_returns_absolute_path(tmp_path: Path) -> None:
+    deck_path = tmp_path / "nested" / "deck.json"
+    deck_path.parent.mkdir()
+    deck = build_deck(template_manifest="templates/demo/manifest.json")
+
+    resolved = resolve_manifest_path(str(deck_path), deck)
+
+    assert resolved == str(deck_path.parent / "templates" / "demo" / "manifest.json")
+
+
+def test_resolve_manifest_path_returns_none_when_manifest_missing(tmp_path: Path) -> None:
+    deck = build_deck()
+
+    assert resolve_manifest_path(str(tmp_path / "deck.json"), deck) is None
 
 
 def test_read_deck_prefers_computed_sidecar_when_present(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add optional `template_manifest` to `Deck`
- upgrade legacy v1 deck payloads to schema v2 on read so updated writes emit `version: 2`
- add `resolve_manifest_path` and sidecar coverage for v1/v2 loading, round-trip serialization, and relative path resolution

## Validation
- `UV_CACHE_DIR=.uv-cache uv run pytest -v tests/test_sidecar.py`
- `UV_CACHE_DIR=.uv-cache uv run pytest -v`
