### PR TITLE
Add inspect command for learned template manifests

### DIFF
--- a/src/agent_slides/cli.py
+++ b/src/agent_slides/cli.py
@@ -10,6 +10,7 @@ from agent_slides import __version__
 from agent_slides.commands.batch import batch
 from agent_slides.commands.build import build_command
 from agent_slides.commands.info import info_command
+from agent_slides.commands.inspect_cmd import inspect_command
 from agent_slides.commands.init import init_command
 from agent_slides.commands.preview import preview_command
 from agent_slides.commands.slide import slide
@@ -56,8 +57,10 @@ cli.add_command(slide)
 cli.add_command(slot)
 cli.add_command(theme)
 cli.add_command(info_command)
+cli.add_command(inspect_command)
 cli.add_command(build_command)
 cli.add_command(preview_command, name="preview")
 cli.add_command(validate_command, name="validate")
 cli.add_command(info_command, name="info")
+cli.add_command(inspect_command, name="inspect")
 cli.add_command(build_command, name="build")

--- a/src/agent_slides/commands/inspect_cmd.py
+++ b/src/agent_slides/commands/inspect_cmd.py
@@ -1,0 +1,112 @@
+"""Inspect command for summarizing learned template manifests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import click
+
+from agent_slides.errors import AgentSlidesError, FILE_NOT_FOUND, SCHEMA_ERROR
+
+
+def _read_manifest(path: Path) -> dict[str, Any]:
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise AgentSlidesError(FILE_NOT_FOUND, f"Manifest file not found: {path}") from exc
+
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise AgentSlidesError(SCHEMA_ERROR, f"Manifest file is not valid JSON: {path}") from exc
+
+    if not isinstance(payload, dict):
+        raise AgentSlidesError(SCHEMA_ERROR, "Manifest root must be a JSON object.")
+
+    return payload
+
+
+def _require_string(payload: dict[str, Any], field: str) -> str:
+    value = payload.get(field)
+    if not isinstance(value, str) or not value:
+        raise AgentSlidesError(SCHEMA_ERROR, f"Manifest field '{field}' must be a non-empty string.")
+    return value
+
+
+def _require_list(payload: dict[str, Any], field: str) -> list[Any]:
+    value = payload.get(field)
+    if not isinstance(value, list):
+        raise AgentSlidesError(SCHEMA_ERROR, f"Manifest field '{field}' must be an array.")
+    return value
+
+
+def _require_dict(payload: dict[str, Any], field: str) -> dict[str, Any]:
+    value = payload.get(field)
+    if not isinstance(value, dict):
+        raise AgentSlidesError(SCHEMA_ERROR, f"Manifest field '{field}' must be an object.")
+    return value
+
+
+def _slot_sort_key(item: tuple[str, Any]) -> tuple[int, str]:
+    slot_name, placeholder_idx = item
+    if isinstance(placeholder_idx, int):
+        return (placeholder_idx, slot_name)
+    return (10**9, slot_name)
+
+
+def _summarize_layout(layout: dict[str, Any]) -> dict[str, Any]:
+    name = _require_string(layout, "name")
+    slug = _require_string(layout, "slug")
+    slot_mapping = _require_dict(layout, "slot_mapping")
+    slots = [slot_name for slot_name, _ in sorted(slot_mapping.items(), key=_slot_sort_key)]
+    usable = bool(slots) or name.casefold() == "blank"
+
+    summary: dict[str, Any] = {
+        "name": name,
+        "slug": slug,
+        "slots": slots,
+        "usable": usable,
+    }
+    if not usable:
+        summary["reason"] = "no typed placeholders"
+    return summary
+
+
+def summarize_manifest(payload: dict[str, Any]) -> dict[str, Any]:
+    source = _require_string(payload, "source")
+    slide_masters = _require_list(payload, "slide_masters")
+
+    layouts: list[dict[str, Any]] = []
+    for index, master in enumerate(slide_masters):
+        if not isinstance(master, dict):
+            raise AgentSlidesError(SCHEMA_ERROR, f"Manifest slide_masters[{index}] must be an object.")
+        for layout_index, layout in enumerate(_require_list(master, "layouts")):
+            if not isinstance(layout, dict):
+                raise AgentSlidesError(
+                    SCHEMA_ERROR,
+                    f"Manifest slide_masters[{index}].layouts[{layout_index}] must be an object.",
+                )
+            layouts.append(_summarize_layout(layout))
+
+    theme = payload.get("theme")
+    return {
+        "ok": True,
+        "data": {
+            "source": source,
+            "layouts_found": len(layouts),
+            "usable_layouts": sum(1 for layout in layouts if layout["usable"]),
+            "theme_extracted": isinstance(theme, dict) and bool(theme),
+            "layouts": layouts,
+        },
+    }
+
+
+@click.command("inspect")
+@click.argument("path", type=click.Path(dir_okay=False, path_type=Path))
+def inspect_command(path: Path) -> None:
+    """Summarize a learned template manifest."""
+
+    manifest = _read_manifest(path)
+    click.echo(json.dumps(summarize_manifest(manifest)))

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -34,6 +34,10 @@ def read_payload(path: Path) -> dict[str, object]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
+def write_json(path: Path, payload: dict[str, object]) -> None:
+    path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
+
+
 def write_deck(path: Path, deck: Deck) -> None:
     payload = json.loads(deck.model_dump_json(by_alias=True))
     for slide in payload["slides"]:
@@ -1024,6 +1028,166 @@ def test_validate_command_returns_structured_overflow_warning(tmp_path: Path) ->
     assert any(warning["code"] == "OVERFLOW" for warning in payload["data"]["warnings"])
     for warning in payload["data"]["warnings"]:
         assert {"code", "severity", "message"} <= warning.keys()
+
+
+def test_inspect_command_summarizes_manifest_json(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "client-brand.manifest.json"
+    write_json(
+        manifest_path,
+        {
+            "source": "client-brand.pptx",
+            "source_hash": "abc123",
+            "slide_masters": [
+                {
+                    "layouts": [
+                        {
+                            "name": "Title Slide",
+                            "slug": "title_slide",
+                            "slot_mapping": {"heading": 0, "subheading": 1},
+                        },
+                        {
+                            "name": "Two Content",
+                            "slug": "two_content",
+                            "slot_mapping": {"heading": 0, "col1": 1, "col2": 2},
+                        },
+                    ]
+                },
+                {
+                    "layouts": [
+                        {
+                            "name": "Blank",
+                            "slug": "blank",
+                            "slot_mapping": {},
+                        },
+                        {
+                            "name": "Custom Layout 4",
+                            "slug": "custom_layout_4",
+                            "slot_mapping": {},
+                        },
+                    ]
+                },
+            ],
+            "theme": {
+                "colors": {"primary": "#112233"},
+                "fonts": {"heading": "Aptos Display", "body": "Aptos"},
+                "spacing": {"base_unit": 10, "margin": 60, "gutter": 20},
+            },
+        },
+    )
+
+    result = invoke_cli(["inspect", str(manifest_path)])
+
+    assert result.exit_code == 0
+    assert result.stderr == ""
+    assert json.loads(result.output) == {
+        "ok": True,
+        "data": {
+            "source": "client-brand.pptx",
+            "layouts_found": 4,
+            "usable_layouts": 3,
+            "theme_extracted": True,
+            "layouts": [
+                {
+                    "name": "Title Slide",
+                    "slug": "title_slide",
+                    "slots": ["heading", "subheading"],
+                    "usable": True,
+                },
+                {
+                    "name": "Two Content",
+                    "slug": "two_content",
+                    "slots": ["heading", "col1", "col2"],
+                    "usable": True,
+                },
+                {
+                    "name": "Blank",
+                    "slug": "blank",
+                    "slots": [],
+                    "usable": True,
+                },
+                {
+                    "name": "Custom Layout 4",
+                    "slug": "custom_layout_4",
+                    "slots": [],
+                    "usable": False,
+                    "reason": "no typed placeholders",
+                },
+            ],
+        },
+    }
+
+
+def test_inspect_command_reports_theme_not_extracted_when_missing(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "manifest.json"
+    write_json(
+        manifest_path,
+        {
+            "source": "template.pptx",
+            "slide_masters": [
+                {
+                    "layouts": [
+                        {
+                            "name": "One Column",
+                            "slug": "one_column",
+                            "slot_mapping": {"body": 3},
+                        }
+                    ]
+                }
+            ],
+        },
+    )
+
+    result = invoke_cli(["inspect", str(manifest_path)])
+
+    assert result.exit_code == 0
+    assert json.loads(result.output) == {
+        "ok": True,
+        "data": {
+            "source": "template.pptx",
+            "layouts_found": 1,
+            "usable_layouts": 1,
+            "theme_extracted": False,
+            "layouts": [
+                {
+                    "name": "One Column",
+                    "slug": "one_column",
+                    "slots": ["body"],
+                    "usable": True,
+                }
+            ],
+        },
+    }
+
+
+def test_inspect_command_reports_missing_manifest_as_file_not_found(tmp_path: Path) -> None:
+    missing_path = tmp_path / "missing.manifest.json"
+
+    result = invoke_cli(["inspect", str(missing_path)])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stderr) == {
+        "ok": False,
+        "error": {
+            "code": FILE_NOT_FOUND,
+            "message": f"Manifest file not found: {missing_path}",
+        },
+    }
+
+
+def test_inspect_command_reports_invalid_json_as_schema_error(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "broken.manifest.json"
+    manifest_path.write_text("{not valid json\n", encoding="utf-8")
+
+    result = invoke_cli(["inspect", str(manifest_path)])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stderr) == {
+        "ok": False,
+        "error": {
+            "code": SCHEMA_ERROR,
+            "message": f"Manifest file is not valid JSON: {manifest_path}",
+        },
+    }
 
 
 def test_info_command_dumps_indented_deck_json(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- add `agent-slides inspect <manifest.json>` to summarize learned template manifests
- derive layout usability, slot lists, and theme extraction status from the manifest schema used by `learn`
- cover success and error paths with focused `CliRunner` tests

Closes #65
