### PR TITLE
Add suggest-layout CLI command

### DIFF
--- a/src/agent_slides/cli.py
+++ b/src/agent_slides/cli.py
@@ -16,6 +16,7 @@ from agent_slides.commands.learn import learn_command
 from agent_slides.commands.preview import preview_command
 from agent_slides.commands.slide import slide
 from agent_slides.commands.slot import slot
+from agent_slides.commands.suggest_layout import suggest_layout_command
 from agent_slides.commands.theme import theme
 from agent_slides.commands.validate_cmd import validate_command
 from agent_slides.errors import AgentSlidesError
@@ -61,6 +62,7 @@ cli.add_command(info_command)
 cli.add_command(learn_command)
 cli.add_command(inspect_command)
 cli.add_command(build_command)
+cli.add_command(suggest_layout_command, name="suggest-layout")
 cli.add_command(preview_command, name="preview")
 cli.add_command(validate_command, name="validate")
 cli.add_command(info_command, name="info")

--- a/src/agent_slides/commands/suggest_layout.py
+++ b/src/agent_slides/commands/suggest_layout.py
@@ -1,0 +1,53 @@
+"""CLI command for built-in layout recommendations."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+from pydantic import ValidationError
+
+from agent_slides.engine.layout_suggestions import serialize_suggestions, suggest_layouts
+from agent_slides.errors import AgentSlidesError, FILE_NOT_FOUND, SCHEMA_ERROR
+from agent_slides.model import NodeContent
+
+
+def _read_content_arg(content_arg: str) -> tuple[object, str]:
+    if content_arg.startswith("@"):
+        path = Path(content_arg[1:])
+        try:
+            raw = path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise AgentSlidesError(FILE_NOT_FOUND, f"Content file not found: {path}") from exc
+        source = str(path)
+    else:
+        raw = content_arg
+        source = "`--content`"
+
+    try:
+        return json.loads(raw), source
+    except json.JSONDecodeError as exc:
+        raise AgentSlidesError(SCHEMA_ERROR, f"Content JSON is not valid: {source}") from exc
+
+
+def _parse_content(content_arg: str) -> NodeContent:
+    payload, source = _read_content_arg(content_arg)
+    if isinstance(payload, str):
+        raise AgentSlidesError(SCHEMA_ERROR, f"Content JSON must describe structured blocks, not a string: {source}")
+
+    try:
+        return NodeContent.model_validate(payload)
+    except ValidationError as exc:
+        raise AgentSlidesError(SCHEMA_ERROR, f"Content JSON does not match the NodeContent schema: {source}") from exc
+
+
+@click.command("suggest-layout")
+@click.option("--content", "content_arg", required=True)
+@click.option("--image-count", default=0, type=click.IntRange(min=0))
+def suggest_layout_command(content_arg: str, image_count: int) -> None:
+    """Recommend built-in layouts for structured text content."""
+
+    content = _parse_content(content_arg)
+    suggestions = suggest_layouts(content, image_count=image_count, limit=3)
+    click.echo(json.dumps({"ok": True, "data": {"suggestions": serialize_suggestions(suggestions)}}))

--- a/src/agent_slides/engine/__init__.py
+++ b/src/agent_slides/engine/__init__.py
@@ -1,8 +1,18 @@
 """Layout and render engine package."""
 
+from agent_slides.engine.layout_suggestions import LayoutSuggestion, suggest_layouts
 from agent_slides.engine.reflow import rebind_slots, reflow_deck
 from agent_slides.engine.template_reflow import template_reflow
 from agent_slides.engine.text_fit import fit_text
 from agent_slides.engine.validator import validate_deck, validate_slide
 
-__all__ = ["fit_text", "rebind_slots", "reflow_deck", "template_reflow", "validate_deck", "validate_slide"]
+__all__ = [
+    "LayoutSuggestion",
+    "fit_text",
+    "rebind_slots",
+    "reflow_deck",
+    "suggest_layouts",
+    "template_reflow",
+    "validate_deck",
+    "validate_slide",
+]

--- a/src/agent_slides/engine/layout_suggestions.py
+++ b/src/agent_slides/engine/layout_suggestions.py
@@ -1,0 +1,143 @@
+"""Heuristics for recommending built-in layouts from structured content."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+
+from agent_slides.model.types import NodeContent
+
+
+@dataclass(frozen=True)
+class LayoutSuggestion:
+    layout: str
+    score: float
+    reason: str
+
+
+def _non_empty_blocks(content: NodeContent) -> list[object]:
+    return [block for block in content.blocks if block.text.strip()]
+
+
+def _add_suggestion(
+    suggestions: dict[str, LayoutSuggestion],
+    *,
+    layout: str,
+    score: float,
+    reason: str,
+) -> None:
+    candidate = LayoutSuggestion(layout=layout, score=round(score, 2), reason=reason)
+    current = suggestions.get(layout)
+    if current is None or candidate.score > current.score:
+        suggestions[layout] = candidate
+
+
+def suggest_layouts(content: NodeContent, *, image_count: int = 0, limit: int = 3) -> list[LayoutSuggestion]:
+    """Return ranked built-in layout suggestions for the provided content."""
+
+    blocks = _non_empty_blocks(content)
+    block_count = len(blocks)
+    heading_count = sum(1 for block in blocks if getattr(block, "type", None) == "heading")
+    bullet_count = content.bullet_count()
+    word_count = content.word_count()
+    has_heading = heading_count > 0
+
+    suggestions: dict[str, LayoutSuggestion] = {}
+
+    if image_count > 0:
+        _add_suggestion(
+            suggestions,
+            layout="image_left",
+            score=0.97 if block_count >= 2 or bullet_count >= 2 else 0.89,
+            reason="Image plus supporting text fits a side-by-side layout.",
+        )
+        _add_suggestion(
+            suggestions,
+            layout="image_right",
+            score=0.96 if block_count >= 2 or bullet_count >= 2 else 0.88,
+            reason="A mirrored side-by-side layout also suits image-backed content.",
+        )
+        _add_suggestion(
+            suggestions,
+            layout="hero_image",
+            score=0.94 if has_heading and block_count <= 2 else 0.84,
+            reason="A strong headline with imagery can work as a hero slide.",
+        )
+        if image_count >= 2:
+            _add_suggestion(
+                suggestions,
+                layout="gallery",
+                score=0.95 if image_count >= 4 else 0.93,
+                reason="Multiple images can be grouped into a gallery treatment.",
+            )
+
+    if has_heading and block_count <= 2 and word_count <= 18:
+        _add_suggestion(
+            suggestions,
+            layout="title",
+            score=0.92,
+            reason="Short heading-led content fits a title slide.",
+        )
+
+    if block_count >= 2 or bullet_count >= 3:
+        _add_suggestion(
+            suggestions,
+            layout="two_col",
+            score=0.94 if bullet_count >= 3 else 0.89,
+            reason="Content splits naturally into two balanced groups.",
+        )
+
+    if block_count >= 4 or bullet_count >= 5:
+        _add_suggestion(
+            suggestions,
+            layout="comparison",
+            score=0.79,
+            reason="Several supporting points could be framed as a comparison.",
+        )
+
+    if block_count >= 5 or bullet_count >= 6:
+        _add_suggestion(
+            suggestions,
+            layout="three_col",
+            score=0.76,
+            reason="Denser content may benefit from a three-column scan pattern.",
+        )
+
+    if block_count == 2 and heading_count == 0 and word_count <= 45:
+        _add_suggestion(
+            suggestions,
+            layout="quote",
+            score=0.75,
+            reason="A main statement plus attribution could read well as a quote slide.",
+        )
+
+    if block_count <= 1 and word_count <= 6:
+        _add_suggestion(
+            suggestions,
+            layout="closing",
+            score=0.7,
+            reason="Very short content can work as a closing slide.",
+        )
+
+    _add_suggestion(
+        suggestions,
+        layout="title_content",
+        score=0.88 if has_heading else 0.72,
+        reason="A single-column title and body layout is a safe baseline fit.",
+    )
+
+    if not suggestions:
+        _add_suggestion(
+            suggestions,
+            layout="title_content",
+            score=0.7,
+            reason="Defaulting to a flexible single-column layout.",
+        )
+
+    ranked = sorted(suggestions.values(), key=lambda item: (-item.score, item.layout))
+    return ranked[:limit]
+
+
+def serialize_suggestions(suggestions: list[LayoutSuggestion]) -> list[dict[str, object]]:
+    """Convert suggestions to JSON-safe dictionaries."""
+
+    return [asdict(suggestion) for suggestion in suggestions]

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -528,6 +528,100 @@ def test_theme_apply_returns_error_for_invalid_theme(tmp_path: Path) -> None:
     assert read_deck(str(deck_path)).theme == "default"
 
 
+def test_suggest_layout_returns_ranked_suggestions_for_inline_content() -> None:
+    result = invoke_cli(
+        [
+            "suggest-layout",
+            "--content",
+            json.dumps(
+                {
+                    "blocks": [
+                        {"type": "heading", "text": "Quarterly update"},
+                        {"type": "bullet", "text": "Revenue up 24%"},
+                        {"type": "bullet", "text": "Margin improved"},
+                        {"type": "bullet", "text": "Hiring plan"},
+                    ]
+                }
+            ),
+        ]
+    )
+
+    assert result.exit_code == 0
+    assert result.stderr == ""
+
+    payload = json.loads(result.output)
+    suggestions = payload["data"]["suggestions"]
+
+    assert payload["ok"] is True
+    assert len(suggestions) == 3
+    assert suggestions[0]["layout"] == "two_col"
+    assert [item["score"] for item in suggestions] == sorted(
+        [item["score"] for item in suggestions],
+        reverse=True,
+    )
+
+
+def test_suggest_layout_accepts_file_reference(tmp_path: Path) -> None:
+    content_path = tmp_path / "content.json"
+    write_json(
+        content_path,
+        {
+            "blocks": [
+                {"type": "heading", "text": "Launch plan"},
+                {"type": "paragraph", "text": "Sequence the rollout in a single narrative arc."},
+            ]
+        },
+    )
+
+    result = invoke_cli(["suggest-layout", "--content", f"@{content_path}"])
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+
+    assert payload["ok"] is True
+    assert any(item["layout"] == "title_content" for item in payload["data"]["suggestions"])
+
+
+def test_suggest_layout_image_count_surfaces_image_layouts() -> None:
+    result = invoke_cli(
+        [
+            "suggest-layout",
+            "--content",
+            json.dumps(
+                {
+                    "blocks": [
+                        {"type": "heading", "text": "Customer story"},
+                        {"type": "paragraph", "text": "Show the product in use with supporting context."},
+                    ]
+                }
+            ),
+            "--image-count",
+            "2",
+        ]
+    )
+
+    assert result.exit_code == 0
+    payload = json.loads(result.output)
+    layouts = [item["layout"] for item in payload["data"]["suggestions"]]
+
+    assert payload["ok"] is True
+    assert set(layouts) <= {"gallery", "hero_image", "image_left", "image_right"}
+    assert layouts[0] in {"hero_image", "image_left", "image_right"}
+
+
+def test_suggest_layout_returns_json_error_for_invalid_content() -> None:
+    result = invoke_cli(["suggest-layout", "--content", "{bad json"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stderr) == {
+        "ok": False,
+        "error": {
+            "code": SCHEMA_ERROR,
+            "message": "Content JSON is not valid: `--content`",
+        },
+    }
+
+
 def test_theme_apply_changes_subsequent_build_output(tmp_path: Path) -> None:
     deck_path = tmp_path / "deck.json"
     default_output = tmp_path / "default.pptx"


### PR DESCRIPTION
## Summary
- add a `suggest-layout` CLI command that accepts inline JSON or `@file` NodeContent payloads
- expose ranked built-in layout suggestions, including image-aware recommendations
- add CliRunner coverage for inline input, file input, image-count behavior, and invalid JSON

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/agent_slides/cli.py src/agent_slides/commands/suggest_layout.py src/agent_slides/engine/__init__.py src/agent_slides/engine/layout_suggestions.py tests/test_commands.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest tests/test_commands.py -v -k suggest`

Closes #82.