### PR TITLE
Add Anthropic tool-use deck orchestrator

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,11 @@ dependencies = [
   "websockets>=16.0",
 ]
 
+[project.optional-dependencies]
+preview = [
+  "anthropic>=0.52.0",
+]
+
 [project.scripts]
 agent-slides = "agent_slides.cli:cli"
 

--- a/src/agent_slides/preview/__init__.py
+++ b/src/agent_slides/preview/__init__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from importlib.resources import files
 from pathlib import Path
 
+from agent_slides.preview.orchestrator import ChatResponse, DeckOrchestrator
 from agent_slides.preview.server import PreviewServer, run_preview_server
 from agent_slides.preview.watcher import SidecarWatcher
 
@@ -22,6 +23,8 @@ def read_client_html() -> str:
 
 
 __all__ = [
+    "ChatResponse",
+    "DeckOrchestrator",
     "PreviewServer",
     "SidecarWatcher",
     "client_html_path",

--- a/src/agent_slides/preview/orchestrator.py
+++ b/src/agent_slides/preview/orchestrator.py
@@ -1,0 +1,505 @@
+"""Anthropic-backed chat orchestrator for deck operations."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, AsyncIterator, Literal
+
+try:
+    import anthropic
+except ImportError:  # pragma: no cover - exercised via runtime guard
+    anthropic = None
+
+from agent_slides.commands.mutations import apply_mutation
+from agent_slides.engine.reflow import reflow_deck
+from agent_slides.engine.template_reflow import template_reflow
+from agent_slides.engine.validator import validate_deck
+from agent_slides.errors import AgentSlidesError, OVERFLOW, UNBOUND_NODES
+from agent_slides.io import mutate_deck, read_deck, resolve_manifest_path, write_computed_deck, write_pptx
+from agent_slides.model.constraints import Constraint
+from agent_slides.model.design_rules import load_design_rules
+from agent_slides.model.layout_provider import TemplateLayoutRegistry, resolve_layout_provider
+
+DEFAULT_MODEL = "claude-sonnet-4-5-20250929"
+MAX_HISTORY_MESSAGES = 20
+MUTATING_TOOLS = frozenset(
+    {
+        "slide_add",
+        "slot_set",
+        "slot_clear",
+        "chart_add",
+        "slide_set_layout",
+        "slide_remove",
+    }
+)
+
+SYSTEM_PROMPT = """
+You are the deck editing assistant for agent-slides.
+
+- Keep responses short and practical.
+- Prefer `slide_add` with `auto_layout: true` unless the user clearly asks for a specific layout.
+- Start decks with a title slide when creating a new presentation.
+- After adding or changing content, use the tool results to check whether the content still fits.
+- When the user asks to build, export, or download the deck, call `build`.
+- Use deck tools instead of describing changes you did not apply.
+""".strip()
+
+SLIDE_REF_SCHEMA: dict[str, Any] = {
+    "anyOf": [
+        {"type": "integer", "minimum": 0},
+        {"type": "string", "minLength": 1},
+    ]
+}
+
+TEXT_BLOCK_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "type": {"type": "string", "enum": ["paragraph", "bullet", "heading"]},
+        "text": {"type": "string"},
+        "level": {"type": "integer", "minimum": 0},
+    },
+    "required": ["type", "text"],
+    "additionalProperties": False,
+}
+
+STRUCTURED_TEXT_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "blocks": {
+            "type": "array",
+            "items": TEXT_BLOCK_SCHEMA,
+        }
+    },
+    "required": ["blocks"],
+    "additionalProperties": False,
+}
+
+CHART_DATA_SCHEMA: dict[str, Any] = {
+    "type": "object",
+    "properties": {
+        "categories": {
+            "type": "array",
+            "items": {"type": "string"},
+        },
+        "series": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {"type": "string"},
+                    "values": {
+                        "type": "array",
+                        "items": {"type": "number"},
+                    },
+                    "points": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "x": {"type": "number"},
+                                "y": {"type": "number"},
+                            },
+                            "required": ["x", "y"],
+                            "additionalProperties": False,
+                        },
+                    },
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        },
+        "style": {
+            "type": "object",
+            "properties": {
+                "has_legend": {"type": "boolean"},
+                "has_data_labels": {"type": "boolean"},
+                "series_colors": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                },
+            },
+            "additionalProperties": False,
+        },
+    },
+    "additionalProperties": True,
+}
+
+TOOL_DEFINITIONS: list[dict[str, Any]] = [
+    {
+        "name": "slide_add",
+        "description": "Add a slide. Prefer auto_layout for new content unless the user requires a specific layout.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "layout": {"type": "string", "minLength": 1},
+                "auto_layout": {"type": "boolean"},
+                "content": STRUCTURED_TEXT_SCHEMA,
+                "image_count": {"type": "integer", "minimum": 0},
+            },
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "slot_set",
+        "description": "Set text, structured content, or an image in a specific slot on a slide.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": SLIDE_REF_SCHEMA,
+                "slot": {"type": "string", "minLength": 1},
+                "text": {"type": "string"},
+                "content": STRUCTURED_TEXT_SCHEMA,
+                "image": {"type": "string", "minLength": 1},
+                "image_fit": {"type": "string", "enum": ["contain", "cover", "stretch"]},
+                "font_size": {"type": "number"},
+            },
+            "required": ["slide", "slot"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "slot_clear",
+        "description": "Remove content from a slot on a slide.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": SLIDE_REF_SCHEMA,
+                "slot": {"type": "string", "minLength": 1},
+            },
+            "required": ["slide", "slot"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "chart_add",
+        "description": "Insert or replace a chart in a slot on a slide.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": SLIDE_REF_SCHEMA,
+                "slot": {"type": "string", "minLength": 1},
+                "type": {
+                    "type": "string",
+                    "enum": ["bar", "column", "line", "pie", "scatter", "area", "doughnut"],
+                },
+                "title": {"type": ["string", "null"]},
+                "data": CHART_DATA_SCHEMA,
+            },
+            "required": ["slide", "slot", "type", "data"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "slide_set_layout",
+        "description": "Change the layout used by an existing slide.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": SLIDE_REF_SCHEMA,
+                "layout": {"type": "string", "minLength": 1},
+            },
+            "required": ["slide", "layout"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "slide_remove",
+        "description": "Remove a slide by index or slide id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": SLIDE_REF_SCHEMA,
+            },
+            "required": ["slide"],
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "get_deck_info",
+        "description": "Read the current deck state, including slides, nodes, theme, and revision.",
+        "input_schema": {
+            "type": "object",
+            "properties": {},
+            "additionalProperties": False,
+        },
+    },
+    {
+        "name": "build",
+        "description": "Reflow the deck, persist computed data, and write a PPTX artifact.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "output_path": {"type": "string", "minLength": 1},
+            },
+            "additionalProperties": False,
+        },
+    },
+]
+
+
+@dataclass
+class ChatResponse:
+    type: Literal["thinking", "tool_call", "assistant_message", "error"]
+    text: str
+    status: Literal["thinking", "executing", "done", "error"]
+    tool_name: str | None = None
+    tool_result: dict[str, Any] | None = None
+
+
+class DeckOrchestrator:
+    """Run multi-turn Anthropic tool-use conversations against a deck."""
+
+    def __init__(self, deck_path: str, api_key: str):
+        if anthropic is None:
+            raise RuntimeError("Anthropic SDK is not installed. Install agent-slides[preview] to enable chat.")
+
+        self.deck_path = str(Path(deck_path).resolve())
+        deck = read_deck(self.deck_path)
+        manifest_path = resolve_manifest_path(self.deck_path, deck)
+        self._layout_provider = resolve_layout_provider(manifest_path)
+        self._design_rules = load_design_rules(deck.design_rules)
+        self.client = anthropic.Anthropic(api_key=api_key)
+        self.conversation: list[dict[str, Any]] = []
+
+    async def handle_message(self, user_text: str) -> AsyncIterator[ChatResponse]:
+        """Process one user turn and yield status updates as work completes."""
+
+        self.conversation.append({"role": "user", "content": user_text})
+        yield ChatResponse(type="thinking", text="Thinking about the deck update.", status="thinking")
+
+        invalid_tool_attempts = 0
+        api_attempts = 0
+
+        while True:
+            try:
+                message = await asyncio.to_thread(self._create_message)
+            except Exception as exc:
+                if api_attempts == 0:
+                    api_attempts += 1
+                    yield ChatResponse(
+                        type="thinking",
+                        text="Anthropic request failed once; retrying.",
+                        status="thinking",
+                    )
+                    continue
+                yield ChatResponse(type="error", text=f"Anthropic API error: {exc}", status="error")
+                return
+
+            api_attempts = 0
+            assistant_message = self._message_to_conversation_item(message)
+            self.conversation.append(assistant_message)
+
+            tool_uses = [block for block in assistant_message["content"] if block.get("type") == "tool_use"]
+            if not tool_uses:
+                text = self._extract_text(assistant_message["content"]) or "Done."
+                yield ChatResponse(type="assistant_message", text=text, status="done")
+                return
+
+            tool_results: list[dict[str, Any]] = []
+            saw_tool_error = False
+            for block in tool_uses:
+                tool_name = str(block.get("name", "")).strip()
+                try:
+                    result = await asyncio.to_thread(self._execute_tool, tool_name, block.get("input"))
+                    saw_tool_error = saw_tool_error or not result.get("ok", True)
+                    response_text = self._tool_response_text(tool_name, result)
+                except Exception as exc:  # pragma: no cover - defensive
+                    saw_tool_error = True
+                    result = self._error_payload(tool_name, exc)
+                    response_text = self._tool_response_text(tool_name, result)
+
+                yield ChatResponse(
+                    type="tool_call",
+                    text=response_text,
+                    status="executing",
+                    tool_name=tool_name or None,
+                    tool_result=result,
+                )
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.get("id"),
+                        "content": json.dumps(result, sort_keys=True),
+                        "is_error": not result.get("ok", True),
+                    }
+                )
+
+            self.conversation.append({"role": "user", "content": tool_results})
+
+            if saw_tool_error:
+                invalid_tool_attempts += 1
+                if invalid_tool_attempts > 1:
+                    error_text = self._tool_error_summary(tool_results)
+                    yield ChatResponse(type="error", text=error_text, status="error")
+                    return
+            else:
+                invalid_tool_attempts = 0
+
+    def _create_message(self) -> Any:
+        return self.client.messages.create(
+            model=DEFAULT_MODEL,
+            max_tokens=1024,
+            system=SYSTEM_PROMPT,
+            tools=TOOL_DEFINITIONS,
+            messages=self._conversation_window(),
+        )
+
+    def _conversation_window(self) -> list[dict[str, Any]]:
+        if len(self.conversation) <= MAX_HISTORY_MESSAGES:
+            return list(self.conversation)
+        return self.conversation[-MAX_HISTORY_MESSAGES:]
+
+    def _execute_tool(self, tool_name: str, raw_input: Any) -> dict[str, Any]:
+        if not isinstance(raw_input, dict):
+            raise AgentSlidesError("INVALID_TOOL_INPUT", "Tool input must be an object")
+
+        if tool_name in MUTATING_TOOLS:
+            return self._run_mutation_tool(tool_name, raw_input)
+        if tool_name == "get_deck_info":
+            return self._run_get_deck_info()
+        if tool_name == "build":
+            return self._run_build_tool(raw_input)
+        raise AgentSlidesError("INVALID_TOOL_NAME", f"Unsupported tool {tool_name!r}")
+
+    def _run_mutation_tool(self, tool_name: str, tool_input: dict[str, Any]) -> dict[str, Any]:
+        deck, mutation_result = mutate_deck(
+            self.deck_path,
+            lambda deck, _provider: apply_mutation(deck, tool_name, tool_input, self._layout_provider),
+        )
+        validation = self._validation_payload(deck)
+        return {
+            "ok": True,
+            "mutation": tool_name,
+            "result": mutation_result,
+            "validation": validation,
+        }
+
+    def _run_get_deck_info(self) -> dict[str, Any]:
+        deck = read_deck(self.deck_path)
+        return {
+            "ok": True,
+            "deck": deck.model_dump(mode="json", by_alias=True),
+        }
+
+    def _run_build_tool(self, tool_input: dict[str, Any]) -> dict[str, Any]:
+        deck = read_deck(self.deck_path)
+        manifest_path = resolve_manifest_path(self.deck_path, deck)
+        provider = resolve_layout_provider(manifest_path)
+        if isinstance(provider, TemplateLayoutRegistry):
+            template_reflow(deck, provider)
+        else:
+            reflow_deck(deck, provider)
+        write_computed_deck(self.deck_path, deck)
+
+        output_path = self._resolve_output_path(tool_input.get("output_path"))
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        write_pptx(deck, str(output_path), asset_base_dir=Path(self.deck_path).parent)
+        return {
+            "ok": True,
+            "output": str(output_path),
+            "slides": len(deck.slides),
+        }
+
+    def _resolve_output_path(self, raw_output_path: Any) -> Path:
+        if raw_output_path is None:
+            return Path(self.deck_path).with_suffix(".pptx")
+        if not isinstance(raw_output_path, str) or not raw_output_path.strip():
+            raise AgentSlidesError("INVALID_TOOL_INPUT", "Argument 'output_path' must be a non-empty string")
+
+        candidate = Path(raw_output_path.strip()).expanduser()
+        if candidate.is_absolute():
+            return candidate
+        return Path(self.deck_path).parent / candidate
+
+    def _validation_payload(self, deck: Any) -> dict[str, Any]:
+        warnings = validate_deck(deck, self._design_rules)
+        suggestions = [suggestion for constraint in warnings if (suggestion := self._constraint_suggestion(constraint))]
+        return {
+            "clean": not warnings,
+            "warnings": [warning.model_dump(mode="json") for warning in warnings],
+            "suggestions": suggestions,
+        }
+
+    def _constraint_suggestion(self, constraint: Constraint) -> str | None:
+        if constraint.code == OVERFLOW:
+            return "Some text is still overflowing. Try shorter text or switch to a wider layout."
+        if constraint.code == UNBOUND_NODES:
+            return "There is orphaned content on the slide. Rebind it to a slot or remove it."
+        return None
+
+    def _message_to_conversation_item(self, message: Any) -> dict[str, Any]:
+        content = [self._serialize_content_block(block) for block in getattr(message, "content", [])]
+        return {
+            "role": "assistant",
+            "content": content,
+        }
+
+    def _serialize_content_block(self, block: Any) -> dict[str, Any]:
+        if isinstance(block, dict):
+            return dict(block)
+        if hasattr(block, "model_dump"):
+            return dict(block.model_dump(mode="json"))
+
+        block_type = getattr(block, "type", None)
+        payload: dict[str, Any] = {}
+        if block_type is not None:
+            payload["type"] = block_type
+        for key in ("id", "name", "input", "text"):
+            value = getattr(block, key, None)
+            if value is not None:
+                payload[key] = value
+        if payload:
+            return payload
+        return {"type": "unknown", "text": str(block)}
+
+    def _extract_text(self, content: list[dict[str, Any]]) -> str:
+        texts = [str(block.get("text", "")).strip() for block in content if block.get("type") == "text"]
+        return "\n".join(text for text in texts if text).strip()
+
+    def _tool_response_text(self, tool_name: str, result: dict[str, Any]) -> str:
+        if not result.get("ok", True):
+            return f"{tool_name} failed: {result['error']['message']}"
+
+        validation = result.get("validation")
+        suggestions = validation.get("suggestions", []) if isinstance(validation, dict) else []
+        if suggestions:
+            return f"{tool_name} completed. " + " ".join(suggestions)
+        return f"{tool_name} completed."
+
+    def _tool_error_summary(self, tool_results: list[dict[str, Any]]) -> str:
+        for block in reversed(tool_results):
+            try:
+                payload = json.loads(str(block.get("content", "{}")))
+            except json.JSONDecodeError:
+                continue
+            if not payload.get("ok", True):
+                error = payload.get("error", {})
+                message = error.get("message")
+                if isinstance(message, str) and message.strip():
+                    return f"Tool call failed twice: {message}"
+        return "Tool call failed twice and could not be recovered."
+
+    def _error_payload(self, tool_name: str, exc: Exception) -> dict[str, Any]:
+        if isinstance(exc, AgentSlidesError):
+            message = exc.message
+            code = exc.code
+            details = exc.details
+        else:
+            message = str(exc) or exc.__class__.__name__
+            code = exc.__class__.__name__
+            details = {}
+        return {
+            "ok": False,
+            "tool": tool_name,
+            "error": {
+                "code": code,
+                "message": message,
+                "details": details,
+            },
+        }
+
+
+__all__ = ["ChatResponse", "DeckOrchestrator", "TOOL_DEFINITIONS"]

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from agent_slides.io import init_deck, read_deck
+from agent_slides.model.constraints import Constraint
+from agent_slides.preview import orchestrator as orchestrator_module
+from agent_slides.preview.orchestrator import DeckOrchestrator
+
+
+def test_orchestrator_executes_tool_calls_and_preserves_conversation_history(
+    tmp_path: Path, monkeypatch
+) -> None:
+    deck_path = tmp_path / "deck.json"
+    init_deck(str(deck_path), "default", "default", False)
+
+    api_calls: list[dict[str, Any]] = []
+    thread_calls: list[str] = []
+
+    install_fake_anthropic(
+        monkeypatch,
+        api_calls,
+        [
+            fake_message(
+                fake_tool_use(
+                    "toolu_1",
+                    "slide_add",
+                    {
+                        "layout": "title",
+                    },
+                )
+            ),
+            fake_message(fake_text("Added the title slide.")),
+            fake_message(fake_tool_use("toolu_2", "get_deck_info", {})),
+            fake_message(fake_text("The deck currently has one slide.")),
+        ],
+    )
+    install_inline_to_thread(monkeypatch, thread_calls)
+
+    orchestrator = DeckOrchestrator(str(deck_path), api_key="test-key")
+
+    first_turn = asyncio.run(collect_responses(orchestrator.handle_message("Create the first slide.")))
+    second_turn = asyncio.run(collect_responses(orchestrator.handle_message("What is in the deck now?")))
+
+    assert first_turn[0].type == "thinking"
+    assert first_turn[1].type == "tool_call"
+    assert first_turn[1].tool_name == "slide_add"
+    assert first_turn[1].tool_result["ok"] is True
+    assert first_turn[1].tool_result["mutation"] == "slide_add"
+    assert first_turn[1].tool_result["result"] == {
+        "layout": "title",
+        "slide_id": "s-1",
+        "slide_index": 0,
+    }
+    warning_codes = {
+        warning["code"] for warning in first_turn[1].tool_result["validation"]["warnings"]
+    }
+    assert "MISSING_CLOSING_SLIDE" in warning_codes
+    assert first_turn[-1].type == "assistant_message"
+    assert first_turn[-1].text == "Added the title slide."
+    assert second_turn[-1].text == "The deck currently has one slide."
+
+    deck = read_deck(str(deck_path))
+    assert len(deck.slides) == 1
+    assert api_calls[0]["messages"] == [{"role": "user", "content": "Create the first slide."}]
+    assert {tool["name"] for tool in api_calls[0]["tools"]} == {
+        "slide_add",
+        "slot_set",
+        "slot_clear",
+        "chart_add",
+        "slide_set_layout",
+        "slide_remove",
+        "get_deck_info",
+        "build",
+    }
+    assert api_calls[1]["messages"][-1]["content"][0]["type"] == "tool_result"
+    tool_result_payload = json.loads(api_calls[1]["messages"][-1]["content"][0]["content"])
+    assert tool_result_payload["result"]["slide_id"] == "s-1"
+    assert len(api_calls[2]["messages"]) == 5
+    assert api_calls[2]["messages"][0]["content"] == "Create the first slide."
+    assert api_calls[2]["messages"][-1]["content"] == "What is in the deck now?"
+    assert thread_calls.count("_create_message") == 4
+    assert thread_calls.count("_execute_tool") == 2
+
+
+def test_orchestrator_surfaces_validation_suggestions_after_mutation(
+    tmp_path: Path, monkeypatch
+) -> None:
+    deck_path = tmp_path / "deck.json"
+    init_deck(str(deck_path), "default", "default", False)
+
+    api_calls: list[dict[str, Any]] = []
+    install_fake_anthropic(
+        monkeypatch,
+        api_calls,
+        [
+            fake_message(fake_tool_use("toolu_1", "slide_add", {"layout": "title"})),
+            fake_message(fake_text("Done.")),
+        ],
+    )
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "validate_deck",
+        lambda deck, rules: [
+            Constraint(
+                code="OVERFLOW",
+                severity="error",
+                message="Text overflowed.",
+                slide_id="s-1",
+                node_id="n-1",
+            ),
+            Constraint(
+                code="UNBOUND_NODES",
+                severity="error",
+                message="Node is unbound.",
+                slide_id="s-1",
+                node_ids=["n-2"],
+            ),
+        ],
+    )
+    install_inline_to_thread(monkeypatch, [])
+
+    orchestrator = DeckOrchestrator(str(deck_path), api_key="test-key")
+    responses = asyncio.run(collect_responses(orchestrator.handle_message("Create a slide.")))
+
+    assert responses[1].type == "tool_call"
+    assert "shorter text or switch to a wider layout" in responses[1].text
+    assert "orphaned content" in responses[1].text
+    assert responses[1].tool_result["validation"]["suggestions"] == [
+        "Some text is still overflowing. Try shorter text or switch to a wider layout.",
+        "There is orphaned content on the slide. Rebind it to a slot or remove it.",
+    ]
+
+
+def test_orchestrator_retries_invalid_tool_calls_once_then_surfaces_error(
+    tmp_path: Path, monkeypatch
+) -> None:
+    deck_path = tmp_path / "deck.json"
+    init_deck(str(deck_path), "default", "default", False)
+
+    api_calls: list[dict[str, Any]] = []
+    install_fake_anthropic(
+        monkeypatch,
+        api_calls,
+        [
+            fake_message(fake_tool_use("toolu_1", "not_a_real_tool", {})),
+            fake_message(fake_tool_use("toolu_2", "still_not_real", {})),
+        ],
+    )
+    install_inline_to_thread(monkeypatch, [])
+
+    orchestrator = DeckOrchestrator(str(deck_path), api_key="test-key")
+    responses = asyncio.run(collect_responses(orchestrator.handle_message("Do something impossible.")))
+
+    assert responses[1].type == "tool_call"
+    assert responses[1].tool_result["ok"] is False
+    assert responses[-1].type == "error"
+    assert "Tool call failed twice" in responses[-1].text
+    assert len(api_calls) == 2
+    assert api_calls[1]["messages"][-1]["content"][0]["is_error"] is True
+
+
+def test_orchestrator_build_tool_writes_requested_output(tmp_path: Path, monkeypatch) -> None:
+    deck_path = tmp_path / "deck.json"
+    init_deck(str(deck_path), "default", "default", False)
+
+    api_calls: list[dict[str, Any]] = []
+    install_fake_anthropic(
+        monkeypatch,
+        api_calls,
+        [
+            fake_message(
+                fake_tool_use(
+                    "toolu_1",
+                    "build",
+                    {
+                        "output_path": "artifacts/demo.pptx",
+                    },
+                )
+            ),
+            fake_message(fake_text("Built the presentation.")),
+        ],
+    )
+    install_inline_to_thread(monkeypatch, [])
+
+    monkeypatch.setattr(
+        orchestrator_module,
+        "write_pptx",
+        lambda deck, output_path, asset_base_dir: Path(output_path).write_bytes(b"pptx"),
+    )
+
+    orchestrator = DeckOrchestrator(str(deck_path), api_key="test-key")
+    responses = asyncio.run(collect_responses(orchestrator.handle_message("Export the deck.")))
+
+    output_path = tmp_path / "artifacts" / "demo.pptx"
+    assert output_path.read_bytes() == b"pptx"
+    assert responses[1].tool_result == {
+        "ok": True,
+        "output": str(output_path),
+        "slides": 0,
+    }
+    assert responses[-1].text == "Built the presentation."
+
+
+async def collect_responses(iterator: Any) -> list[Any]:
+    responses = []
+    async for item in iterator:
+        responses.append(item)
+    return responses
+
+
+def install_inline_to_thread(monkeypatch, recorded_names: list[str]) -> None:
+    async def fake_to_thread(func, /, *args, **kwargs):
+        recorded_names.append(getattr(func, "__name__", func.__class__.__name__))
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(orchestrator_module.asyncio, "to_thread", fake_to_thread)
+
+
+def install_fake_anthropic(monkeypatch, api_calls: list[dict[str, Any]], responses: list[Any]) -> None:
+    iterator = iter(responses)
+
+    class FakeMessagesAPI:
+        def create(self, **kwargs):
+            api_calls.append(kwargs)
+            return next(iterator)
+
+    class FakeClient:
+        def __init__(self, api_key: str):
+            self.api_key = api_key
+            self.messages = FakeMessagesAPI()
+
+    monkeypatch.setattr(orchestrator_module, "anthropic", SimpleNamespace(Anthropic=FakeClient))
+
+
+def fake_message(*content_blocks: Any) -> Any:
+    return SimpleNamespace(content=list(content_blocks))
+
+
+def fake_tool_use(tool_id: str, name: str, payload: dict[str, Any]) -> Any:
+    return SimpleNamespace(type="tool_use", id=tool_id, name=name, input=payload)
+
+
+def fake_text(text: str) -> Any:
+    return SimpleNamespace(type="text", text=text)

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -21,8 +21,6 @@ from agent_slides.model.types import (
     Deck,
     Node,
     NodeContent,
-    ScatterPoint,
-    ScatterSeries,
     Slide,
     TextBlock,
 )

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,11 @@ dependencies = [
     { name = "websockets" },
 ]
 
+[package.optional-dependencies]
+preview = [
+    { name = "anthropic" },
+]
+
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
@@ -23,6 +28,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'preview'", specifier = ">=0.52.0" },
     { name = "click", specifier = ">=8.1" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "python-pptx", specifier = ">=1.0.2" },
@@ -30,6 +36,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0" },
     { name = "websockets", specifier = ">=16.0" },
 ]
+provides-extras = ["preview"]
 
 [package.metadata.requires-dev]
 dev = [
@@ -44,6 +51,47 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "anthropic"
+version = "0.86.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "distro" },
+    { name = "docstring-parser" },
+    { name = "httpx" },
+    { name = "jiter" },
+    { name = "pydantic" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/37/7a/8b390dc47945d3169875d342847431e5f7d5fa716b2e37494d57cfc1db10/anthropic-0.86.0.tar.gz", hash = "sha256:60023a7e879aa4fbb1fed99d487fe407b2ebf6569603e5047cfe304cebdaa0e5", size = 583820, upload-time = "2026-03-18T18:43:08.017Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/63/5f/67db29c6e5d16c8c9c4652d3efb934d89cb750cad201539141781d8eae14/anthropic-0.86.0-py3-none-any.whl", hash = "sha256:9d2bbd339446acce98858c5627d33056efe01f70435b22b63546fe7edae0cd57", size = 469400, upload-time = "2026-03-18T18:43:06.526Z" },
+]
+
+[[package]]
+name = "anyio"
+version = "4.13.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "idna" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
 ]
 
 [[package]]
@@ -68,12 +116,161 @@ wheels = [
 ]
 
 [[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
+]
+
+[[package]]
+name = "docstring-parser"
+version = "0.17.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b2/9d/c3b43da9515bd270df0f80548d9944e389870713cc1fe2b8fb35fe2bcefd/docstring_parser-0.17.0.tar.gz", hash = "sha256:583de4a309722b3315439bb31d64ba3eebada841f2e2cee23b99df001434c912", size = 27442, upload-time = "2025-07-21T07:35:01.868Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/e2/2537ebcff11c1ee1ff17d8d0b6f4db75873e3b0fb32c2d4a2ee31ecb310a/docstring_parser-0.17.0-py3-none-any.whl", hash = "sha256:cf2569abd23dce8099b300f9b4fa8191e9582dda731fd533daf54c4551658708", size = 36896, upload-time = "2025-07-21T07:35:00.684Z" },
+]
+
+[[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
+]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jiter"
+version = "0.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0d/5e/4ec91646aee381d01cdb9974e30882c9cd3b8c5d1079d6b5ff4af522439a/jiter-0.13.0.tar.gz", hash = "sha256:f2839f9c2c7e2dffc1bc5929a510e14ce0a946be9365fd1219e7ef342dae14f4", size = 164847, upload-time = "2026-02-02T12:37:56.441Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/71/29/499f8c9eaa8a16751b1c0e45e6f5f1761d180da873d417996cc7bddc8eef/jiter-0.13.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:ea026e70a9a28ebbdddcbcf0f1323128a8db66898a06eaad3a4e62d2f554d096", size = 311157, upload-time = "2026-02-02T12:35:37.758Z" },
+    { url = "https://files.pythonhosted.org/packages/50/f6/566364c777d2ab450b92100bea11333c64c38d32caf8dc378b48e5b20c46/jiter-0.13.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:66aa3e663840152d18cc8ff1e4faad3dd181373491b9cfdc6004b92198d67911", size = 319729, upload-time = "2026-02-02T12:35:39.246Z" },
+    { url = "https://files.pythonhosted.org/packages/73/dd/560f13ec5e4f116d8ad2658781646cca91b617ae3b8758d4a5076b278f70/jiter-0.13.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3524798e70655ff19aec58c7d05adb1f074fecff62da857ea9be2b908b6d701", size = 354766, upload-time = "2026-02-02T12:35:40.662Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/0d/061faffcfe94608cbc28a0d42a77a74222bdf5055ccdbe5fd2292b94f510/jiter-0.13.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ec7e287d7fbd02cb6e22f9a00dd9c9cd504c40a61f2c61e7e1f9690a82726b4c", size = 362587, upload-time = "2026-02-02T12:35:42.025Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c9/c66a7864982fd38a9773ec6e932e0398d1262677b8c60faecd02ffb67bf3/jiter-0.13.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:47455245307e4debf2ce6c6e65a717550a0244231240dcf3b8f7d64e4c2f22f4", size = 487537, upload-time = "2026-02-02T12:35:43.459Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/86/84eb4352cd3668f16d1a88929b5888a3fe0418ea8c1dfc2ad4e7bf6e069a/jiter-0.13.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ee9da221dca6e0429c2704c1b3655fe7b025204a71d4d9b73390c759d776d165", size = 373717, upload-time = "2026-02-02T12:35:44.928Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/09/9fe4c159358176f82d4390407a03f506a8659ed13ca3ac93a843402acecf/jiter-0.13.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24ab43126d5e05f3d53a36a8e11eb2f23304c6c1117844aaaf9a0aa5e40b5018", size = 362683, upload-time = "2026-02-02T12:35:46.636Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/5e/85f3ab9caca0c1d0897937d378b4a515cae9e119730563572361ea0c48ae/jiter-0.13.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9da38b4fedde4fb528c740c2564628fbab737166a0e73d6d46cb4bb5463ff411", size = 392345, upload-time = "2026-02-02T12:35:48.088Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4c/05b8629ad546191939e6f0c2f17e29f542a398f4a52fb987bc70b6d1eb8b/jiter-0.13.0-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:0b34c519e17658ed88d5047999a93547f8889f3c1824120c26ad6be5f27b6cf5", size = 517775, upload-time = "2026-02-02T12:35:49.482Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/88/367ea2eb6bc582c7052e4baf5ddf57ebe5ab924a88e0e09830dfb585c02d/jiter-0.13.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:d2a6394e6af690d462310a86b53c47ad75ac8c21dc79f120714ea449979cb1d3", size = 551325, upload-time = "2026-02-02T12:35:51.104Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/12/fa377ffb94a2f28c41afaed093e0d70cfe512035d5ecb0cad0ae4792d35e/jiter-0.13.0-cp311-cp311-win32.whl", hash = "sha256:0f0c065695f616a27c920a56ad0d4fc46415ef8b806bf8fc1cacf25002bd24e1", size = 204709, upload-time = "2026-02-02T12:35:52.467Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/16/8e8203ce92f844dfcd3d9d6a5a7322c77077248dbb12da52d23193a839cd/jiter-0.13.0-cp311-cp311-win_amd64.whl", hash = "sha256:0733312953b909688ae3c2d58d043aa040f9f1a6a75693defed7bc2cc4bf2654", size = 204560, upload-time = "2026-02-02T12:35:53.925Z" },
+    { url = "https://files.pythonhosted.org/packages/44/26/97cc40663deb17b9e13c3a5cf29251788c271b18ee4d262c8f94798b8336/jiter-0.13.0-cp311-cp311-win_arm64.whl", hash = "sha256:5d9b34ad56761b3bf0fbe8f7e55468704107608512350962d3317ffd7a4382d5", size = 189608, upload-time = "2026-02-02T12:35:55.304Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/30/7687e4f87086829955013ca12a9233523349767f69653ebc27036313def9/jiter-0.13.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:0a2bd69fc1d902e89925fc34d1da51b2128019423d7b339a45d9e99c894e0663", size = 307958, upload-time = "2026-02-02T12:35:57.165Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/27/e57f9a783246ed95481e6749cc5002a8a767a73177a83c63ea71f0528b90/jiter-0.13.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f917a04240ef31898182f76a332f508f2cc4b57d2b4d7ad2dbfebbfe167eb505", size = 318597, upload-time = "2026-02-02T12:35:58.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/52/e5719a60ac5d4d7c5995461a94ad5ef962a37c8bf5b088390e6fad59b2ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c1e2b199f446d3e82246b4fd9236d7cb502dc2222b18698ba0d986d2fecc6152", size = 348821, upload-time = "2026-02-02T12:36:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/61/db/c1efc32b8ba4c740ab3fc2d037d8753f67685f475e26b9d6536a4322bcdd/jiter-0.13.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:04670992b576fa65bd056dbac0c39fe8bd67681c380cb2b48efa885711d9d726", size = 364163, upload-time = "2026-02-02T12:36:01.937Z" },
+    { url = "https://files.pythonhosted.org/packages/55/8a/fb75556236047c8806995671a18e4a0ad646ed255276f51a20f32dceaeec/jiter-0.13.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5a1aff1fbdb803a376d4d22a8f63f8e7ccbce0b4890c26cc7af9e501ab339ef0", size = 483709, upload-time = "2026-02-02T12:36:03.41Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/16/43512e6ee863875693a8e6f6d532e19d650779d6ba9a81593ae40a9088ff/jiter-0.13.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:3b3fb8c2053acaef8580809ac1d1f7481a0a0bdc012fd7f5d8b18fb696a5a089", size = 370480, upload-time = "2026-02-02T12:36:04.791Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/4c/09b93e30e984a187bc8aaa3510e1ec8dcbdcd71ca05d2f56aac0492453aa/jiter-0.13.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bdaba7d87e66f26a2c45d8cbadcbfc4bf7884182317907baf39cfe9775bb4d93", size = 360735, upload-time = "2026-02-02T12:36:06.994Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/46c5e349019874ec5dfa508c14c37e29864ea108d376ae26d90bee238cd7/jiter-0.13.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7b88d649135aca526da172e48083da915ec086b54e8e73a425ba50999468cc08", size = 391814, upload-time = "2026-02-02T12:36:08.368Z" },
+    { url = "https://files.pythonhosted.org/packages/15/9e/26184760e85baee7162ad37b7912797d2077718476bf91517641c92b3639/jiter-0.13.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:e404ea551d35438013c64b4f357b0474c7abf9f781c06d44fcaf7a14c69ff9e2", size = 513990, upload-time = "2026-02-02T12:36:09.993Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/34/2c9355247d6debad57a0a15e76ab1566ab799388042743656e566b3b7de1/jiter-0.13.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:1f4748aad1b4a93c8bdd70f604d0f748cdc0e8744c5547798acfa52f10e79228", size = 548021, upload-time = "2026-02-02T12:36:11.376Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/4a/9f2c23255d04a834398b9c2e0e665382116911dc4d06b795710503cdad25/jiter-0.13.0-cp312-cp312-win32.whl", hash = "sha256:0bf670e3b1445fc4d31612199f1744f67f889ee1bbae703c4b54dc097e5dd394", size = 203024, upload-time = "2026-02-02T12:36:12.682Z" },
+    { url = "https://files.pythonhosted.org/packages/09/ee/f0ae675a957ae5a8f160be3e87acea6b11dc7b89f6b7ab057e77b2d2b13a/jiter-0.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:15db60e121e11fe186c0b15236bd5d18381b9ddacdcf4e659feb96fc6c969c92", size = 205424, upload-time = "2026-02-02T12:36:13.93Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/02/ae611edf913d3cbf02c97cdb90374af2082c48d7190d74c1111dde08bcdd/jiter-0.13.0-cp312-cp312-win_arm64.whl", hash = "sha256:41f92313d17989102f3cb5dd533a02787cdb99454d494344b0361355da52fcb9", size = 186818, upload-time = "2026-02-02T12:36:15.308Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9c/7ee5a6ff4b9991e1a45263bfc46731634c4a2bde27dfda6c8251df2d958c/jiter-0.13.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:1f8a55b848cbabf97d861495cd65f1e5c590246fabca8b48e1747c4dfc8f85bf", size = 306897, upload-time = "2026-02-02T12:36:16.748Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/02/be5b870d1d2be5dd6a91bdfb90f248fbb7dcbd21338f092c6b89817c3dbf/jiter-0.13.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f556aa591c00f2c45eb1b89f68f52441a016034d18b65da60e2d2875bbbf344a", size = 317507, upload-time = "2026-02-02T12:36:18.351Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/b25d2ec333615f5f284f3a4024f7ce68cfa0604c322c6808b2344c7f5d2b/jiter-0.13.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f7e1d61da332ec412350463891923f960c3073cf1aae93b538f0bb4c8cd46efb", size = 350560, upload-time = "2026-02-02T12:36:19.746Z" },
+    { url = "https://files.pythonhosted.org/packages/be/ec/74dcb99fef0aca9fbe56b303bf79f6bd839010cb18ad41000bf6cc71eec0/jiter-0.13.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3097d665a27bc96fd9bbf7f86178037db139f319f785e4757ce7ccbf390db6c2", size = 363232, upload-time = "2026-02-02T12:36:21.243Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/37/f17375e0bb2f6a812d4dd92d7616e41917f740f3e71343627da9db2824ce/jiter-0.13.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d01ecc3a8cbdb6f25a37bd500510550b64ddf9f7d64a107d92f3ccb25035d0f", size = 483727, upload-time = "2026-02-02T12:36:22.688Z" },
+    { url = "https://files.pythonhosted.org/packages/77/d2/a71160a5ae1a1e66c1395b37ef77da67513b0adba73b993a27fbe47eb048/jiter-0.13.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ed9bbc30f5d60a3bdf63ae76beb3f9db280d7f195dfcfa61af792d6ce912d159", size = 370799, upload-time = "2026-02-02T12:36:24.106Z" },
+    { url = "https://files.pythonhosted.org/packages/01/99/ed5e478ff0eb4e8aa5fd998f9d69603c9fd3f32de3bd16c2b1194f68361c/jiter-0.13.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98fbafb6e88256f4454de33c1f40203d09fc33ed19162a68b3b257b29ca7f663", size = 359120, upload-time = "2026-02-02T12:36:25.519Z" },
+    { url = "https://files.pythonhosted.org/packages/16/be/7ffd08203277a813f732ba897352797fa9493faf8dc7995b31f3d9cb9488/jiter-0.13.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5467696f6b827f1116556cb0db620440380434591e93ecee7fd14d1a491b6daa", size = 390664, upload-time = "2026-02-02T12:36:26.866Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/84/e0787856196d6d346264d6dcccb01f741e5f0bd014c1d9a2ebe149caf4f3/jiter-0.13.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:2d08c9475d48b92892583df9da592a0e2ac49bcd41fae1fec4f39ba6cf107820", size = 513543, upload-time = "2026-02-02T12:36:28.217Z" },
+    { url = "https://files.pythonhosted.org/packages/65/50/ecbd258181c4313cf79bca6c88fb63207d04d5bf5e4f65174114d072aa55/jiter-0.13.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:aed40e099404721d7fcaf5b89bd3b4568a4666358bcac7b6b15c09fb6252ab68", size = 547262, upload-time = "2026-02-02T12:36:29.678Z" },
+    { url = "https://files.pythonhosted.org/packages/27/da/68f38d12e7111d2016cd198161b36e1f042bd115c169255bcb7ec823a3bf/jiter-0.13.0-cp313-cp313-win32.whl", hash = "sha256:36ebfbcffafb146d0e6ffb3e74d51e03d9c35ce7c625c8066cdbfc7b953bdc72", size = 200630, upload-time = "2026-02-02T12:36:31.808Z" },
+    { url = "https://files.pythonhosted.org/packages/25/65/3bd1a972c9a08ecd22eb3b08a95d1941ebe6938aea620c246cf426ae09c2/jiter-0.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:8d76029f077379374cf0dbc78dbe45b38dec4a2eb78b08b5194ce836b2517afc", size = 202602, upload-time = "2026-02-02T12:36:33.679Z" },
+    { url = "https://files.pythonhosted.org/packages/15/fe/13bd3678a311aa67686bb303654792c48206a112068f8b0b21426eb6851e/jiter-0.13.0-cp313-cp313-win_arm64.whl", hash = "sha256:bb7613e1a427cfcb6ea4544f9ac566b93d5bf67e0d48c787eca673ff9c9dff2b", size = 185939, upload-time = "2026-02-02T12:36:35.065Z" },
+    { url = "https://files.pythonhosted.org/packages/49/19/a929ec002ad3228bc97ca01dbb14f7632fffdc84a95ec92ceaf4145688ae/jiter-0.13.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:fa476ab5dd49f3bf3a168e05f89358c75a17608dbabb080ef65f96b27c19ab10", size = 316616, upload-time = "2026-02-02T12:36:36.579Z" },
+    { url = "https://files.pythonhosted.org/packages/52/56/d19a9a194afa37c1728831e5fb81b7722c3de18a3109e8f282bfc23e587a/jiter-0.13.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ade8cb6ff5632a62b7dbd4757d8c5573f7a2e9ae285d6b5b841707d8363205ef", size = 346850, upload-time = "2026-02-02T12:36:38.058Z" },
+    { url = "https://files.pythonhosted.org/packages/36/4a/94e831c6bf287754a8a019cb966ed39ff8be6ab78cadecf08df3bb02d505/jiter-0.13.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9950290340acc1adaded363edd94baebcee7dabdfa8bee4790794cd5cfad2af6", size = 358551, upload-time = "2026-02-02T12:36:39.417Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/ec/a4c72c822695fa80e55d2b4142b73f0012035d9fcf90eccc56bc060db37c/jiter-0.13.0-cp313-cp313t-win_amd64.whl", hash = "sha256:2b4972c6df33731aac0742b64fd0d18e0a69bc7d6e03108ce7d40c85fd9e3e6d", size = 201950, upload-time = "2026-02-02T12:36:40.791Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/00/393553ec27b824fbc29047e9c7cd4a3951d7fbe4a76743f17e44034fa4e4/jiter-0.13.0-cp313-cp313t-win_arm64.whl", hash = "sha256:701a1e77d1e593c1b435315ff625fd071f0998c5f02792038a5ca98899261b7d", size = 185852, upload-time = "2026-02-02T12:36:42.077Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f5/f1997e987211f6f9bd71b8083047b316208b4aca0b529bb5f8c96c89ef3e/jiter-0.13.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:cc5223ab19fe25e2f0bf2643204ad7318896fe3729bf12fde41b77bfc4fafff0", size = 308804, upload-time = "2026-02-02T12:36:43.496Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/8f/5482a7677731fd44881f0204981ce2d7175db271f82cba2085dd2212e095/jiter-0.13.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9776ebe51713acf438fd9b4405fcd86893ae5d03487546dae7f34993217f8a91", size = 318787, upload-time = "2026-02-02T12:36:45.071Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/b9/7257ac59778f1cd025b26a23c5520a36a424f7f1b068f2442a5b499b7464/jiter-0.13.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:879e768938e7b49b5e90b7e3fecc0dbec01b8cb89595861fb39a8967c5220d09", size = 353880, upload-time = "2026-02-02T12:36:47.365Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/87/719eec4a3f0841dad99e3d3604ee4cba36af4419a76f3cb0b8e2e691ad67/jiter-0.13.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:682161a67adea11e3aae9038c06c8b4a9a71023228767477d683f69903ebc607", size = 366702, upload-time = "2026-02-02T12:36:48.871Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/65/415f0a75cf6921e43365a1bc227c565cb949caca8b7532776e430cbaa530/jiter-0.13.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:a13b68cd1cd8cc9de8f244ebae18ccb3e4067ad205220ef324c39181e23bbf66", size = 486319, upload-time = "2026-02-02T12:36:53.006Z" },
+    { url = "https://files.pythonhosted.org/packages/54/a2/9e12b48e82c6bbc6081fd81abf915e1443add1b13d8fc586e1d90bb02bb8/jiter-0.13.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:87ce0f14c6c08892b610686ae8be350bf368467b6acd5085a5b65441e2bf36d2", size = 372289, upload-time = "2026-02-02T12:36:54.593Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/c1/e4693f107a1789a239c759a432e9afc592366f04e901470c2af89cfd28e1/jiter-0.13.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c365005b05505a90d1c47856420980d0237adf82f70c4aff7aebd3c1cc143ad", size = 360165, upload-time = "2026-02-02T12:36:56.112Z" },
+    { url = "https://files.pythonhosted.org/packages/17/08/91b9ea976c1c758240614bd88442681a87672eebc3d9a6dde476874e706b/jiter-0.13.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1317fdffd16f5873e46ce27d0e0f7f4f90f0cdf1d86bf6abeaea9f63ca2c401d", size = 389634, upload-time = "2026-02-02T12:36:57.495Z" },
+    { url = "https://files.pythonhosted.org/packages/18/23/58325ef99390d6d40427ed6005bf1ad54f2577866594bcf13ce55675f87d/jiter-0.13.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:c05b450d37ba0c9e21c77fef1f205f56bcee2330bddca68d344baebfc55ae0df", size = 514933, upload-time = "2026-02-02T12:36:58.909Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/25/69f1120c7c395fd276c3996bb8adefa9c6b84c12bb7111e5c6ccdcd8526d/jiter-0.13.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:775e10de3849d0631a97c603f996f518159272db00fdda0a780f81752255ee9d", size = 548842, upload-time = "2026-02-02T12:37:00.433Z" },
+    { url = "https://files.pythonhosted.org/packages/18/05/981c9669d86850c5fbb0d9e62bba144787f9fba84546ba43d624ee27ef29/jiter-0.13.0-cp314-cp314-win32.whl", hash = "sha256:632bf7c1d28421c00dd8bbb8a3bac5663e1f57d5cd5ed962bce3c73bf62608e6", size = 202108, upload-time = "2026-02-02T12:37:01.718Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/96/cdcf54dd0b0341db7d25413229888a346c7130bd20820530905fdb65727b/jiter-0.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:f22ef501c3f87ede88f23f9b11e608581c14f04db59b6a801f354397ae13739f", size = 204027, upload-time = "2026-02-02T12:37:03.075Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/f9/724bcaaab7a3cd727031fe4f6995cb86c4bd344909177c186699c8dec51a/jiter-0.13.0-cp314-cp314-win_arm64.whl", hash = "sha256:07b75fe09a4ee8e0c606200622e571e44943f47254f95e2436c8bdcaceb36d7d", size = 187199, upload-time = "2026-02-02T12:37:04.414Z" },
+    { url = "https://files.pythonhosted.org/packages/62/92/1661d8b9fd6a3d7a2d89831db26fe3c1509a287d83ad7838831c7b7a5c7e/jiter-0.13.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:964538479359059a35fb400e769295d4b315ae61e4105396d355a12f7fef09f0", size = 318423, upload-time = "2026-02-02T12:37:05.806Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/3b/f77d342a54d4ebcd128e520fc58ec2f5b30a423b0fd26acdfc0c6fef8e26/jiter-0.13.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e104da1db1c0991b3eaed391ccd650ae8d947eab1480c733e5a3fb28d4313e40", size = 351438, upload-time = "2026-02-02T12:37:07.189Z" },
+    { url = "https://files.pythonhosted.org/packages/76/b3/ba9a69f0e4209bd3331470c723c2f5509e6f0482e416b612431a5061ed71/jiter-0.13.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0e3a5f0cde8ff433b8e88e41aa40131455420fb3649a3c7abdda6145f8cb7202", size = 364774, upload-time = "2026-02-02T12:37:08.579Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/16/6cdb31fa342932602458dbb631bfbd47f601e03d2e4950740e0b2100b570/jiter-0.13.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:57aab48f40be1db920a582b30b116fe2435d184f77f0e4226f546794cedd9cf0", size = 487238, upload-time = "2026-02-02T12:37:10.066Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/b1/956cc7abaca8d95c13aa8d6c9b3f3797241c246cd6e792934cc4c8b250d2/jiter-0.13.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7772115877c53f62beeb8fd853cab692dbc04374ef623b30f997959a4c0e7e95", size = 372892, upload-time = "2026-02-02T12:37:11.656Z" },
+    { url = "https://files.pythonhosted.org/packages/26/c4/97ecde8b1e74f67b8598c57c6fccf6df86ea7861ed29da84629cdbba76c4/jiter-0.13.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1211427574b17b633cfceba5040de8081e5abf114f7a7602f73d2e16f9fdaa59", size = 360309, upload-time = "2026-02-02T12:37:13.244Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/d7/eabe3cf46715854ccc80be2cd78dd4c36aedeb30751dbf85a1d08c14373c/jiter-0.13.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:7beae3a3d3b5212d3a55d2961db3c292e02e302feb43fce6a3f7a31b90ea6dfe", size = 389607, upload-time = "2026-02-02T12:37:14.881Z" },
+    { url = "https://files.pythonhosted.org/packages/df/2d/03963fc0804e6109b82decfb9974eb92df3797fe7222428cae12f8ccaa0c/jiter-0.13.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:e5562a0f0e90a6223b704163ea28e831bd3a9faa3512a711f031611e6b06c939", size = 514986, upload-time = "2026-02-02T12:37:16.326Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/6c/8c83b45eb3eb1c1e18d841fe30b4b5bc5619d781267ca9bc03e005d8fd0a/jiter-0.13.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:6c26a424569a59140fb51160a56df13f438a2b0967365e987889186d5fc2f6f9", size = 548756, upload-time = "2026-02-02T12:37:17.736Z" },
+    { url = "https://files.pythonhosted.org/packages/47/66/eea81dfff765ed66c68fd2ed8c96245109e13c896c2a5015c7839c92367e/jiter-0.13.0-cp314-cp314t-win32.whl", hash = "sha256:24dc96eca9f84da4131cdf87a95e6ce36765c3b156fc9ae33280873b1c32d5f6", size = 201196, upload-time = "2026-02-02T12:37:19.101Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/32/4ac9c7a76402f8f00d00842a7f6b83b284d0cf7c1e9d4227bc95aa6d17fa/jiter-0.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:0a8d76c7524087272c8ae913f5d9d608bd839154b62c4322ef65723d2e5bb0b8", size = 204215, upload-time = "2026-02-02T12:37:20.495Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/8e/7def204fea9f9be8b3c21a6f2dd6c020cf56c7d5ff753e0e23ed7f9ea57e/jiter-0.13.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2c26cf47e2cad140fa23b6d58d435a7c0161f5c514284802f25e87fddfe11024", size = 187152, upload-time = "2026-02-02T12:37:22.124Z" },
+    { url = "https://files.pythonhosted.org/packages/79/b3/3c29819a27178d0e461a8571fb63c6ae38be6dc36b78b3ec2876bbd6a910/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b1cbfa133241d0e6bdab48dcdc2604e8ba81512f6bbd68ec3e8e1357dd3c316c", size = 307016, upload-time = "2026-02-02T12:37:42.755Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/ae/60993e4b07b1ac5ebe46da7aa99fdbb802eb986c38d26e3883ac0125c4e0/jiter-0.13.0-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:db367d8be9fad6e8ebbac4a7578b7af562e506211036cba2c06c3b998603c3d2", size = 305024, upload-time = "2026-02-02T12:37:44.774Z" },
+    { url = "https://files.pythonhosted.org/packages/77/fa/2227e590e9cf98803db2811f172b2d6460a21539ab73006f251c66f44b14/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:45f6f8efb2f3b0603092401dc2df79fa89ccbc027aaba4174d2d4133ed661434", size = 339337, upload-time = "2026-02-02T12:37:46.668Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/92/015173281f7eb96c0ef580c997da8ef50870d4f7f4c9e03c845a1d62ae04/jiter-0.13.0-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:597245258e6ad085d064780abfb23a284d418d3e61c57362d9449c6c7317ee2d", size = 346395, upload-time = "2026-02-02T12:37:48.09Z" },
+    { url = "https://files.pythonhosted.org/packages/80/60/e50fa45dd7e2eae049f0ce964663849e897300433921198aef94b6ffa23a/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:3d744a6061afba08dd7ae375dcde870cffb14429b7477e10f67e9e6d68772a0a", size = 305169, upload-time = "2026-02-02T12:37:50.376Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/73/a009f41c5eed71c49bec53036c4b33555afcdee70682a18c6f66e396c039/jiter-0.13.0-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:ff732bd0a0e778f43d5009840f20b935e79087b4dc65bd36f1cd0f9b04b8ff7f", size = 303808, upload-time = "2026-02-02T12:37:52.092Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/10/528b439290763bff3d939268085d03382471b442f212dca4ff5f12802d43/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ab44b178f7981fcaea7e0a5df20e773c663d06ffda0198f1a524e91b2fde7e59", size = 337384, upload-time = "2026-02-02T12:37:53.582Z" },
+    { url = "https://files.pythonhosted.org/packages/67/8a/a342b2f0251f3dac4ca17618265d93bf244a2a4d089126e81e4c1056ac50/jiter-0.13.0-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7bb00b6d26db67a05fe3e12c76edc75f32077fb51deed13822dc648fa373bc19", size = 343768, upload-time = "2026-02-02T12:37:55.055Z" },
 ]
 
 [[package]]
@@ -513,6 +710,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/37/e6/90b2b33419f59d0f2c4c8a48a4b74b460709a557e8e0064cf33ad894f983/ruff-0.15.8-py3-none-win32.whl", hash = "sha256:bc1f0a51254ba21767bfa9a8b5013ca8149dcf38092e6a9eb704d876de94dc34", size = 10571959, upload-time = "2026-03-26T18:39:36.117Z" },
     { url = "https://files.pythonhosted.org/packages/1f/a2/ef467cb77099062317154c63f234b8a7baf7cb690b99af760c5b68b9ee7f/ruff-0.15.8-py3-none-win_amd64.whl", hash = "sha256:04f79eff02a72db209d47d665ba7ebcad609d8918a134f86cb13dd132159fc89", size = 11743893, upload-time = "2026-03-26T18:39:25.01Z" },
     { url = "https://files.pythonhosted.org/packages/15/e2/77be4fff062fa78d9b2a4dea85d14785dac5f1d0c1fb58ed52331f0ebe28/ruff-0.15.8-py3-none-win_arm64.whl", hash = "sha256:cf891fa8e3bb430c0e7fac93851a5978fc99c8fa2c053b57b118972866f8e5f2", size = 11048175, upload-time = "2026-03-26T18:40:01.06Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- add a preview-layer `DeckOrchestrator` that drives Anthropic tool-use against deck mutations, deck reads, and PPTX builds
- run mutations through `mutate_deck()` + `apply_mutation()`, preserve conversation history, and surface validation suggestions for overflow and unbound nodes
- add focused orchestrator tests and expose the optional Anthropic preview dependency

## Validation
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/test_orchestrator.py -v`
- `UV_CACHE_DIR=.uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=.uv-cache uv run pytest -v`

Closes #101