### PR TITLE
Add chat CLI command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+chat = ["anthropic>=0.40.0"]
 preview = [
   "anthropic>=0.52.0",
 ]

--- a/src/agent_slides/cli.py
+++ b/src/agent_slides/cli.py
@@ -9,6 +9,7 @@ import click
 from agent_slides import __version__
 from agent_slides.commands.batch import batch
 from agent_slides.commands.build import build_command
+from agent_slides.commands.chat import chat_command
 from agent_slides.commands.chart import chart
 from agent_slides.commands.info import info_command
 from agent_slides.commands.inspect_cmd import inspect_command
@@ -54,6 +55,7 @@ def cli() -> None:
 
 
 cli.add_command(batch)
+cli.add_command(chat_command)
 cli.add_command(chart)
 cli.add_command(init_command)
 cli.add_command(preview_command)

--- a/src/agent_slides/commands/chat.py
+++ b/src/agent_slides/commands/chat.py
@@ -1,0 +1,95 @@
+"""CLI command for running the chat-mode preview server."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import webbrowser
+from pathlib import Path
+
+import click
+
+from agent_slides.commands.preview import _ForegroundPreviewServer, _wait_for_shutdown
+from agent_slides.errors import AgentSlidesError, SCHEMA_ERROR
+from agent_slides.io import init_deck
+from agent_slides.model import load_design_rules
+from agent_slides.model.themes import load_theme
+from agent_slides.preview import DeckOrchestrator
+
+
+def _require_api_key() -> str:
+    api_key = os.environ.get("ANTHROPIC_API_KEY")
+    if api_key:
+        return api_key
+
+    raise AgentSlidesError(
+        SCHEMA_ERROR,
+        "Chat mode requires `ANTHROPIC_API_KEY`. Set the environment variable and try again.",
+    )
+
+
+def _require_anthropic_dependency() -> None:
+    if importlib.util.find_spec("anthropic") is not None:
+        return
+
+    raise AgentSlidesError(
+        SCHEMA_ERROR,
+        "Chat mode requires: pip install agent-slides[chat]",
+    )
+
+
+def _ensure_deck_exists(path: Path) -> None:
+    if path.exists():
+        return
+
+    load_design_rules("default")
+    load_theme("default")
+    init_deck(str(path), theme="default", design_rules="default", force=False)
+
+
+@click.command("chat")
+@click.argument("path", type=click.Path(dir_okay=False, path_type=Path))
+@click.option("--port", type=int, default=8765, show_default=True)
+@click.option("--no-open", is_flag=True, default=False)
+def chat_command(path: Path, port: int, no_open: bool) -> None:
+    """Start the chat-mode preview HTTP server."""
+
+    api_key = _require_api_key()
+    _require_anthropic_dependency()
+    _ensure_deck_exists(path)
+
+    server = _ForegroundPreviewServer(
+        path,
+        port=port,
+        mode="chat",
+        orchestrator=DeckOrchestrator(path, api_key),
+    )
+    server.start()
+
+    try:
+        if not no_open:
+            try:
+                webbrowser.open(server.url)
+            except Exception:
+                pass
+
+        click.echo(
+            json.dumps(
+                {
+                    "ok": True,
+                    "data": {
+                        "url": server.url,
+                        "mode": "chat",
+                    },
+                }
+            )
+        )
+
+        try:
+            _wait_for_shutdown()
+        except KeyboardInterrupt:
+            pass
+    finally:
+        server.stop()
+        click.echo(json.dumps({"ok": True, "data": {"stopped": True}}))

--- a/src/agent_slides/commands/preview.py
+++ b/src/agent_slides/commands/preview.py
@@ -21,8 +21,21 @@ def _wait_for_shutdown() -> None:
 
 
 class _ForegroundPreviewServer:
-    def __init__(self, path: Path, *, port: int) -> None:
-        self._server = PreviewServer(str(path), port=port)
+    def __init__(
+        self,
+        path: Path,
+        *,
+        port: int,
+        mode: str = "preview",
+        orchestrator: object | None = None,
+    ) -> None:
+        self._orchestrator = orchestrator
+        self._server = PreviewServer(
+            str(path),
+            port=port,
+            mode=mode,
+            chat_message_handler=self._chat_message_handler if orchestrator is not None else None,
+        )
         self._thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stop_event: asyncio.Event | None = None
@@ -67,6 +80,33 @@ class _ForegroundPreviewServer:
 
         self._loop.run_until_complete(serve())
         self._loop.close()
+
+    async def _chat_message_handler(
+        self,
+        payload: dict[str, object],
+        emit,
+    ) -> None:
+        if self._orchestrator is None or not hasattr(self._orchestrator, "handle_message"):
+            await emit({"type": "error", "text": "No chat handler configured."})
+            return
+
+        message_type = payload.get("type")
+        user_text = payload.get("text")
+        if message_type != "user_message" or not isinstance(user_text, str) or not user_text.strip():
+            await emit({"type": "error", "text": "Chat messages must include non-empty user text."})
+            return
+
+        async for response in self._orchestrator.handle_message(user_text.strip()):
+            message = {
+                "type": response.type,
+                "text": response.text,
+                "status": response.status,
+            }
+            if response.tool_name is not None:
+                message["tool_name"] = response.tool_name
+            if response.tool_result is not None:
+                message["tool_result"] = response.tool_result
+            await emit(message)
 
 
 @click.command("preview")

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -2089,3 +2089,153 @@ def test_preview_command_reports_missing_deck_as_file_not_found(tmp_path: Path) 
             "message": f"Deck file not found: {missing_path}",
         },
     }
+
+
+def test_chat_command_auto_creates_deck_starts_chat_mode_and_opens_browser(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    deck_path = tmp_path / "deck.json"
+    browser_calls: list[str] = []
+    orchestrator_calls: list[tuple[Path, str]] = []
+    server_events: list[tuple[str, object]] = []
+
+    class FakeServer:
+        def __init__(
+            self,
+            path: Path,
+            *,
+            port: int,
+            mode: str = "preview",
+            orchestrator: object | None = None,
+        ) -> None:
+            self.url = f"http://localhost:{port}"
+            server_events.append(("init", path, port, mode, orchestrator))
+
+        def start(self) -> None:
+            server_events.append(("start",))
+
+        def stop(self) -> None:
+            server_events.append(("stop",))
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr("agent_slides.commands.chat.importlib.util.find_spec", lambda name: object())
+    monkeypatch.setattr("agent_slides.commands.chat._ForegroundPreviewServer", FakeServer)
+    monkeypatch.setattr(
+        "agent_slides.commands.chat.DeckOrchestrator",
+        lambda path, api_key: orchestrator_calls.append((path, api_key)) or object(),
+    )
+    monkeypatch.setattr(
+        "agent_slides.commands.chat._wait_for_shutdown",
+        lambda: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    monkeypatch.setattr(
+        "agent_slides.commands.chat.webbrowser.open",
+        lambda url: browser_calls.append(url),
+    )
+
+    result = invoke_cli(["chat", str(deck_path), "--port", "9876"])
+
+    lines = [line for line in result.output.strip().splitlines() if line]
+
+    assert result.exit_code == 0
+    assert result.stderr == ""
+    assert deck_path.exists()
+    assert read_payload(deck_path)["theme"] == "default"
+    assert browser_calls == ["http://localhost:9876"]
+    assert orchestrator_calls == [(deck_path, "test-key")]
+    assert server_events[0][:4] == ("init", deck_path, 9876, "chat")
+    assert server_events[1] == ("start",)
+    assert server_events[2] == ("stop",)
+    assert json.loads(lines[0]) == {
+        "ok": True,
+        "data": {
+            "url": "http://localhost:9876",
+            "mode": "chat",
+        },
+    }
+    assert json.loads(lines[1]) == {"ok": True, "data": {"stopped": True}}
+
+
+def test_chat_command_supports_custom_port_and_no_open(tmp_path: Path, monkeypatch) -> None:
+    deck_path = tmp_path / "deck.json"
+    write_deck(deck_path, make_clean_deck())
+    browser_calls: list[str] = []
+    server_events: list[tuple[str, object]] = []
+
+    class FakeServer:
+        def __init__(
+            self,
+            path: Path,
+            *,
+            port: int,
+            mode: str = "preview",
+            orchestrator: object | None = None,
+        ) -> None:
+            self.url = f"http://localhost:{port}"
+            server_events.append(("init", path, port, mode, orchestrator))
+
+        def start(self) -> None:
+            server_events.append(("start",))
+
+        def stop(self) -> None:
+            server_events.append(("stop",))
+
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr("agent_slides.commands.chat.importlib.util.find_spec", lambda name: object())
+    monkeypatch.setattr("agent_slides.commands.chat._ForegroundPreviewServer", FakeServer)
+    monkeypatch.setattr("agent_slides.commands.chat.DeckOrchestrator", lambda *args: object())
+    monkeypatch.setattr(
+        "agent_slides.commands.chat._wait_for_shutdown",
+        lambda: (_ for _ in ()).throw(KeyboardInterrupt()),
+    )
+    monkeypatch.setattr(
+        "agent_slides.commands.chat.webbrowser.open",
+        lambda url: browser_calls.append(url),
+    )
+
+    result = invoke_cli(["chat", str(deck_path), "--port", "9012", "--no-open"])
+
+    lines = [line for line in result.output.strip().splitlines() if line]
+
+    assert result.exit_code == 0
+    assert browser_calls == []
+    assert server_events[0][:4] == ("init", deck_path, 9012, "chat")
+    assert json.loads(lines[0])["data"] == {
+        "url": "http://localhost:9012",
+        "mode": "chat",
+    }
+    assert json.loads(lines[1]) == {"ok": True, "data": {"stopped": True}}
+
+
+def test_chat_command_requires_api_key(tmp_path: Path, monkeypatch) -> None:
+    deck_path = tmp_path / "deck.json"
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+
+    result = invoke_cli(["chat", str(deck_path), "--no-open"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stderr) == {
+        "ok": False,
+        "error": {
+            "code": SCHEMA_ERROR,
+            "message": "Chat mode requires `ANTHROPIC_API_KEY`. Set the environment variable and try again.",
+        },
+    }
+
+
+def test_chat_command_reports_missing_anthropic_dependency(tmp_path: Path, monkeypatch) -> None:
+    deck_path = tmp_path / "deck.json"
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-key")
+    monkeypatch.setattr("agent_slides.commands.chat.importlib.util.find_spec", lambda name: None)
+
+    result = invoke_cli(["chat", str(deck_path), "--no-open"])
+
+    assert result.exit_code == 1
+    assert json.loads(result.stderr) == {
+        "ok": False,
+        "error": {
+            "code": SCHEMA_ERROR,
+            "message": "Chat mode requires: pip install agent-slides[chat]",
+        },
+    }

--- a/uv.lock
+++ b/uv.lock
@@ -16,6 +16,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+chat = [
+    { name = "anthropic" },
+]
 preview = [
     { name = "anthropic" },
 ]
@@ -28,6 +31,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "anthropic", marker = "extra == 'chat'", specifier = ">=0.40.0" },
     { name = "anthropic", marker = "extra == 'preview'", specifier = ">=0.52.0" },
     { name = "click", specifier = ">=8.1" },
     { name = "pydantic", specifier = ">=2.0" },
@@ -36,7 +40,7 @@ requires-dist = [
     { name = "watchdog", specifier = ">=6.0" },
     { name = "websockets", specifier = ">=16.0" },
 ]
-provides-extras = ["preview"]
+provides-extras = ["chat", "preview"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
## Summary
- add `agent-slides chat` with Anthropic dependency checks, deck auto-init, and chat-mode startup
- add chat-mode preview asset and server mode support
- cover the new CLI and chat-mode server behavior with tests

Closes #103
