### PR TITLE
Add conversational deck orchestration E2E coverage

### DIFF
--- a/src/agent_slides/orchestrator.py
+++ b/src/agent_slides/orchestrator.py
@@ -1,0 +1,363 @@
+"""Conversational orchestration on top of the deck mutation pipeline."""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from agent_slides.commands.mutations import SUPPORTED_MUTATION_COMMANDS, apply_mutation
+from agent_slides.engine.reflow import reflow_deck
+from agent_slides.engine.template_reflow import template_reflow
+from agent_slides.engine.validator import validate_deck
+from agent_slides.errors import AgentSlidesError, SCHEMA_ERROR
+from agent_slides.io import mutate_deck, read_deck, resolve_manifest_path, write_computed_deck, write_pptx
+from agent_slides.model.design_rules import load_design_rules
+from agent_slides.model.layout_provider import TemplateLayoutRegistry, resolve_layout_provider
+
+DEFAULT_MODEL = "claude-3-7-sonnet-latest"
+DEFAULT_MAX_TOKENS = 1024
+MAX_MODEL_ROUNDS = 8
+
+TOOL_SCHEMAS = [
+    {
+        "name": "slide_add",
+        "description": "Add a slide using a built-in semantic layout.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "layout": {"type": "string"},
+                "auto_layout": {"type": "boolean"},
+                "content": {"type": "object"},
+                "image_count": {"type": "integer"},
+            },
+        },
+    },
+    {
+        "name": "slide_set_layout",
+        "description": "Switch a slide to a different semantic layout.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+                "layout": {"type": "string"},
+            },
+            "required": ["slide", "layout"],
+        },
+    },
+    {
+        "name": "slot_set",
+        "description": "Set text or image content in a slide slot.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+                "slot": {"type": "string"},
+                "text": {"type": "string"},
+                "content": {"type": "object"},
+                "image": {"type": "string"},
+                "font_size": {"type": "number"},
+            },
+            "required": ["slide", "slot"],
+        },
+    },
+    {
+        "name": "slot_clear",
+        "description": "Remove content from a slot on a slide.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+                "slot": {"type": "string"},
+            },
+            "required": ["slide", "slot"],
+        },
+    },
+    {
+        "name": "slot_bind",
+        "description": "Bind an existing node to a slot.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "node": {"type": "string"},
+                "slot": {"type": "string"},
+            },
+            "required": ["node", "slot"],
+        },
+    },
+    {
+        "name": "slide_remove",
+        "description": "Remove a slide by index or slide id.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "slide": {"anyOf": [{"type": "integer"}, {"type": "string"}]},
+            },
+            "required": ["slide"],
+        },
+    },
+    {
+        "name": "build",
+        "description": "Build the current deck into a PPTX file.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "output": {"type": "string"},
+            },
+        },
+    },
+]
+
+_MISSING = object()
+
+
+def _field(obj: object, name: str, default: object = _MISSING) -> Any:
+    if isinstance(obj, dict):
+        if name in obj:
+            return obj[name]
+    elif hasattr(obj, name):
+        return getattr(obj, name)
+
+    if default is not _MISSING:
+        return default
+    raise AttributeError(name)
+
+
+def _normalize_content_blocks(blocks: list[Any]) -> list[dict[str, Any]]:
+    normalized: list[dict[str, Any]] = []
+    for block in blocks:
+        payload: dict[str, Any]
+        if isinstance(block, dict):
+            payload = dict(block)
+        else:
+            payload = {}
+            for name in ("type", "text", "id", "name", "input", "tool_use_id", "content", "is_error"):
+                value = _field(block, name, _MISSING)
+                if value is not _MISSING:
+                    payload[name] = value
+        normalized.append(payload)
+    return normalized
+
+
+def _text_from_blocks(blocks: list[dict[str, Any]]) -> str:
+    values = [
+        str(block["text"]).strip()
+        for block in blocks
+        if block.get("type") == "text" and isinstance(block.get("text"), str) and block["text"].strip()
+    ]
+    return "\n".join(values)
+
+
+def _tool_uses_from_blocks(blocks: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    return [block for block in blocks if block.get("type") == "tool_use"]
+
+
+def _tool_result_block(tool_use_id: str, payload: dict[str, Any], *, is_error: bool) -> dict[str, Any]:
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_use_id,
+        "is_error": is_error,
+        "content": json.dumps(payload, sort_keys=True),
+    }
+
+
+def _serialize_error(exc: AgentSlidesError) -> dict[str, Any]:
+    return {
+        "code": exc.code,
+        "message": exc.message,
+        **exc.details,
+    }
+
+
+@dataclass(slots=True)
+class ConversationTurnResult:
+    """Structured result for one user turn."""
+
+    ok: bool
+    reply: str
+    tool_results: list[dict[str, Any]] = field(default_factory=list)
+    warnings: list[dict[str, Any]] = field(default_factory=list)
+    deck_revision: int | None = None
+    output_path: str | None = None
+    download_url: str | None = None
+    error: dict[str, Any] | None = None
+
+
+class DeckConversationOrchestrator:
+    """Run Anthropic-style tool-use conversations against a deck sidecar."""
+
+    def __init__(
+        self,
+        deck_path: str | Path,
+        anthropic_client: Any,
+        *,
+        model: str = DEFAULT_MODEL,
+        max_tokens: int = DEFAULT_MAX_TOKENS,
+        output_dir: str | Path | None = None,
+        max_error_retries: int = 1,
+    ) -> None:
+        self.deck_path = Path(deck_path).resolve()
+        self.anthropic_client = anthropic_client
+        self.model = model
+        self.max_tokens = max_tokens
+        self.output_dir = Path(output_dir).resolve() if output_dir is not None else self.deck_path.parent
+        self.max_error_retries = max_error_retries
+        self.messages: list[dict[str, Any]] = []
+
+    def send_user_message(self, prompt: str) -> ConversationTurnResult:
+        """Append a user prompt and execute tool rounds until the assistant responds."""
+
+        self.messages.append({"role": "user", "content": [{"type": "text", "text": prompt}]})
+        reply = ""
+        tool_results: list[dict[str, Any]] = []
+        warnings: list[dict[str, Any]] = []
+        output_path: str | None = None
+        download_url: str | None = None
+        last_error: dict[str, Any] | None = None
+        error_retries = 0
+
+        for _ in range(MAX_MODEL_ROUNDS):
+            response = self.anthropic_client.messages.create(
+                model=self.model,
+                max_tokens=self.max_tokens,
+                tools=TOOL_SCHEMAS,
+                messages=self.messages,
+            )
+            assistant_blocks = _normalize_content_blocks(_field(response, "content"))
+            self.messages.append({"role": "assistant", "content": assistant_blocks})
+
+            current_reply = _text_from_blocks(assistant_blocks)
+            if current_reply:
+                reply = current_reply
+
+            tool_uses = _tool_uses_from_blocks(assistant_blocks)
+            if not tool_uses:
+                return ConversationTurnResult(
+                    ok=last_error is None,
+                    reply=reply,
+                    tool_results=tool_results,
+                    warnings=warnings,
+                    deck_revision=self._deck_revision(),
+                    output_path=output_path,
+                    download_url=download_url,
+                    error=last_error,
+                )
+
+            result_blocks: list[dict[str, Any]] = []
+            had_error = False
+            turn_succeeded = False
+
+            for tool_use in tool_uses:
+                payload, is_error = self._execute_tool_use(tool_use)
+                tool_results.append(payload)
+                result_blocks.append(
+                    _tool_result_block(str(tool_use["id"]), payload, is_error=is_error)
+                )
+                if is_error:
+                    had_error = True
+                    last_error = payload["error"]
+                    continue
+
+                turn_succeeded = True
+                last_error = None
+                warnings = payload.get("warnings", warnings)
+                output_path = payload.get("output_path", output_path)
+                download_url = payload.get("download_url", download_url)
+
+            self.messages.append({"role": "user", "content": result_blocks})
+
+            if had_error:
+                if error_retries >= self.max_error_retries:
+                    return ConversationTurnResult(
+                        ok=False,
+                        reply=reply,
+                        tool_results=tool_results,
+                        warnings=warnings,
+                        deck_revision=self._deck_revision(),
+                        output_path=output_path,
+                        download_url=download_url,
+                        error=last_error,
+                    )
+                error_retries += 1
+            elif turn_succeeded:
+                error_retries = 0
+
+        raise RuntimeError("Conversation exceeded the maximum tool-use rounds")
+
+    def _execute_tool_use(self, tool_use: dict[str, Any]) -> tuple[dict[str, Any], bool]:
+        name = tool_use.get("name")
+        raw_input = tool_use.get("input", {})
+        if not isinstance(raw_input, dict):
+            error = AgentSlidesError(SCHEMA_ERROR, f"Tool {name!r} requires an object input payload")
+            return {"ok": False, "tool": name, "error": _serialize_error(error)}, True
+
+        try:
+            if name == "build":
+                return self._execute_build(raw_input), False
+
+            if name not in SUPPORTED_MUTATION_COMMANDS:
+                raise AgentSlidesError(
+                    SCHEMA_ERROR,
+                    f"Unsupported tool {name!r}. Supported tools: {', '.join(sorted((*SUPPORTED_MUTATION_COMMANDS, 'build')))}",
+                )
+
+            deck, result = mutate_deck(
+                str(self.deck_path),
+                lambda deck, provider: apply_mutation(deck, str(name), raw_input, provider),
+            )
+            warnings = self._warnings_for_deck(deck)
+            return {
+                "ok": True,
+                "tool": name,
+                "result": result,
+                "warnings": warnings,
+                "deck_revision": deck.revision,
+            }, False
+        except AgentSlidesError as exc:
+            return {"ok": False, "tool": name, "error": _serialize_error(exc)}, True
+
+    def _execute_build(self, args: dict[str, Any]) -> dict[str, Any]:
+        output_value = args.get("output")
+        if output_value is None:
+            output_path = self.output_dir / f"{self.deck_path.stem}.pptx"
+        elif isinstance(output_value, str) and output_value.strip():
+            candidate = Path(output_value.strip())
+            output_path = candidate if candidate.is_absolute() else self.output_dir / candidate
+        else:
+            raise AgentSlidesError(SCHEMA_ERROR, "Build tool argument 'output' must be a non-empty string")
+
+        deck = read_deck(str(self.deck_path))
+        manifest_path = resolve_manifest_path(str(self.deck_path), deck)
+        if manifest_path is not None:
+            deck.template_manifest = manifest_path
+        provider = resolve_layout_provider(manifest_path)
+        if isinstance(provider, TemplateLayoutRegistry):
+            template_reflow(deck, provider)
+        else:
+            reflow_deck(deck, provider)
+        write_computed_deck(str(self.deck_path), deck)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        write_pptx(deck, str(output_path), asset_base_dir=self.deck_path.parent)
+        return {
+            "ok": True,
+            "tool": "build",
+            "result": {
+                "slides": len(deck.slides),
+                "output": str(output_path),
+            },
+            "warnings": self._warnings_for_deck(deck),
+            "deck_revision": deck.revision,
+            "output_path": str(output_path),
+            "download_url": output_path.resolve().as_uri(),
+        }
+
+    def _deck_revision(self) -> int | None:
+        try:
+            return read_deck(str(self.deck_path)).revision
+        except AgentSlidesError:
+            return None
+
+    def _warnings_for_deck(self, deck: Any) -> list[dict[str, Any]]:
+        rules = load_design_rules(deck.design_rules)
+        return [warning.model_dump(mode="json") for warning in validate_deck(deck, rules)]

--- a/tests/test_e2e_chat.py
+++ b/tests/test_e2e_chat.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+from websockets.asyncio.client import connect
+
+from agent_slides.io.sidecar import init_deck, read_deck
+from agent_slides.orchestrator import DeckConversationOrchestrator
+from agent_slides.preview import PreviewServer
+
+
+class FakeAnthropic:
+    def __init__(self, responses: list[list[dict[str, Any]]]) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self._responses = list(responses)
+        self.messages = SimpleNamespace(create=self._create)
+
+    def _create(self, **kwargs: Any) -> Any:
+        snapshot = dict(kwargs)
+        snapshot["messages"] = json.loads(json.dumps(kwargs["messages"]))
+        self.calls.append(snapshot)
+        if not self._responses:
+            raise AssertionError("No fake Anthropic responses remaining")
+        return SimpleNamespace(content=self._responses.pop(0))
+
+
+def text_block(text: str) -> dict[str, Any]:
+    return {"type": "text", "text": text}
+
+
+def tool_use(tool_id: str, name: str, payload: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "type": "tool_use",
+        "id": tool_id,
+        "name": name,
+        "input": payload,
+    }
+
+
+def prepare_deck(tmp_path: Path) -> Path:
+    deck_path = tmp_path / "deck.json"
+    init_deck(str(deck_path), theme="default", design_rules="default", force=False)
+    return deck_path
+
+
+async def receive_update(websocket: Any, *, timeout: float = 0.5) -> dict[str, Any]:
+    async with asyncio.timeout(timeout):
+        message = await websocket.recv()
+    return json.loads(message)
+
+
+async def collect_updates(websocket: Any, *, timeout: float) -> list[dict[str, Any]]:
+    updates = [await receive_update(websocket)]
+    while True:
+        try:
+            async with asyncio.timeout(timeout):
+                message = await websocket.recv()
+        except TimeoutError:
+            return updates
+        updates.append(json.loads(message))
+
+
+def test_single_message_creates_slide_and_pushes_preview_update(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        deck_path = prepare_deck(tmp_path)
+        client = FakeAnthropic(
+            [
+                [
+                    tool_use("toolu-1", "slide_add", {"layout": "title"}),
+                    tool_use(
+                        "toolu-2",
+                        "slot_set",
+                        {"slide": 0, "slot": "title", "text": "Conversational Deck"},
+                    ),
+                ],
+                [text_block("Created the opening slide.")],
+            ]
+        )
+        orchestrator = DeckConversationOrchestrator(deck_path, client)
+
+        async with PreviewServer(str(deck_path), host="127.0.0.1", port=0) as server:
+            async with connect(server.url) as websocket:
+                result = orchestrator.send_user_message("Create an opening slide")
+                updates = await collect_updates(websocket, timeout=0.25)
+
+        deck = read_deck(str(deck_path))
+        assert result.ok is True
+        assert result.reply == "Created the opening slide."
+        assert len(deck.slides) == 1
+        assert deck.slides[0].layout == "title"
+        assert deck.slides[0].nodes[0].content.to_plain_text() == "Conversational Deck"
+        assert len(updates) >= 1
+        assert updates[-1]["deck"]["slides"][0]["nodes"][0]["content"]["blocks"] == [
+            {"type": "paragraph", "text": "Conversational Deck", "level": 0}
+        ]
+
+    asyncio.run(scenario())
+
+
+def test_multi_turn_conversation_preserves_history_and_builds(tmp_path: Path) -> None:
+    deck_path = prepare_deck(tmp_path)
+    client = FakeAnthropic(
+        [
+            [
+                tool_use("toolu-1", "slide_add", {"layout": "title_content"}),
+                tool_use("toolu-2", "slot_set", {"slide": 0, "slot": "title", "text": "Launch Plan"}),
+            ],
+            [text_block("Added the first slide.")],
+            [
+                tool_use(
+                    "toolu-3",
+                    "slot_set",
+                    {
+                        "slide": 0,
+                        "slot": "body",
+                        "text": "Priority one\nPriority two\nPriority three",
+                    },
+                ),
+                tool_use("toolu-4", "slide_set_layout", {"slide": 0, "layout": "two_col"}),
+                tool_use("toolu-5", "build", {"output": "chat-export.pptx"}),
+            ],
+            [text_block("Updated the deck and exported the PPTX.")],
+        ]
+    )
+    orchestrator = DeckConversationOrchestrator(deck_path, client)
+
+    first = orchestrator.send_user_message("Start a launch plan deck")
+    second = orchestrator.send_user_message("Add the agenda, switch to two columns, and export it")
+
+    deck = read_deck(str(deck_path))
+    output_path = tmp_path / "chat-export.pptx"
+
+    assert first.ok is True
+    assert second.ok is True
+    assert len(deck.slides) == 1
+    assert deck.slides[0].layout == "two_col"
+    assert output_path.exists()
+    assert second.output_path == str(output_path)
+    assert second.download_url == output_path.resolve().as_uri()
+    assert len(orchestrator.messages) > len(client.calls[0]["messages"])
+    assert len(client.calls[2]["messages"]) > len(client.calls[0]["messages"])
+
+
+def test_auto_validate_after_mutation_surfaces_overflow_warning(tmp_path: Path) -> None:
+    deck_path = prepare_deck(tmp_path)
+    client = FakeAnthropic(
+        [
+            [
+                tool_use("toolu-1", "slide_add", {"layout": "title_content"}),
+                tool_use(
+                    "toolu-2",
+                    "slot_set",
+                    {
+                        "slide": 0,
+                        "slot": "body",
+                        "text": " ".join(["overflow"] * 1200),
+                    },
+                ),
+            ],
+            [text_block("I added the content.")],
+        ]
+    )
+    orchestrator = DeckConversationOrchestrator(deck_path, client)
+
+    result = orchestrator.send_user_message("Add a dense content slide")
+
+    assert result.ok is True
+    assert any(warning["code"] == "OVERFLOW" for warning in result.warnings)
+
+
+def test_build_tool_creates_pptx_and_returns_download_url(tmp_path: Path) -> None:
+    deck_path = prepare_deck(tmp_path)
+    client = FakeAnthropic(
+        [
+            [
+                tool_use("toolu-1", "slide_add", {"layout": "title"}),
+                tool_use("toolu-2", "slot_set", {"slide": 0, "slot": "title", "text": "Export Me"}),
+            ],
+            [text_block("Prepared the slide.")],
+            [
+                tool_use("toolu-3", "build", {"output": "downloads/final-deck.pptx"}),
+            ],
+            [text_block("Export is ready.")],
+        ]
+    )
+    orchestrator = DeckConversationOrchestrator(deck_path, client)
+
+    orchestrator.send_user_message("Create a title slide")
+    result = orchestrator.send_user_message("Build the deck")
+
+    expected = tmp_path / "downloads" / "final-deck.pptx"
+    assert result.ok is True
+    assert expected.exists()
+    assert result.output_path == str(expected)
+    assert result.download_url == expected.resolve().as_uri()
+
+
+def test_invalid_tool_call_retries_once_then_surfaces_error(tmp_path: Path) -> None:
+    deck_path = prepare_deck(tmp_path)
+    client = FakeAnthropic(
+        [
+            [
+                tool_use("toolu-1", "slot_set", {"slide": 99, "slot": "title", "text": "Nope"}),
+            ],
+            [
+                tool_use("toolu-2", "slot_set", {"slide": 99, "slot": "title", "text": "Still nope"}),
+            ],
+        ]
+    )
+    orchestrator = DeckConversationOrchestrator(deck_path, client, max_error_retries=1)
+
+    result = orchestrator.send_user_message("Write into a missing slide")
+
+    assert result.ok is False
+    assert result.error is not None
+    assert result.error["code"] == "INVALID_SLIDE"
+    assert len(client.calls) == 2
+    assert read_deck(str(deck_path)).slides == []

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -21,8 +21,6 @@ from agent_slides.model.types import (
     Deck,
     Node,
     NodeContent,
-    ScatterPoint,
-    ScatterSeries,
     Slide,
     TextBlock,
 )


### PR DESCRIPTION
## Summary
- add an internal Anthropic-style conversation orchestrator that executes existing deck mutations and build operations
- add `tests/test_e2e_chat.py` covering slide creation, multi-turn history, overflow validation, PPTX export, and retry/error recovery
- clean up two unused imports in `tests/test_types.py` so repo lint passes

## Validation
- `UV_CACHE_DIR=.uv-cache uv run pytest tests/test_e2e_chat.py -v`
- `UV_CACHE_DIR=.uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=.uv-cache uv run pytest -v`

Closes #104