### PR TITLE
Use native PowerPoint bullets in PPTX writer

### DIFF
--- a/src/agent_slides/io/pptx_writer.py
+++ b/src/agent_slides/io/pptx_writer.py
@@ -14,6 +14,7 @@ from pptx.chart.data import CategoryChartData, XyChartData
 from pptx.dml.color import RGBColor
 from pptx.enum.chart import XL_CHART_TYPE
 from pptx.enum.text import MSO_AUTO_SIZE
+from pptx.oxml.xmlchemy import OxmlElement
 from pptx.parts.image import Image
 from pptx.shapes.shapetree import SlideShapes
 from pptx.util import Emu, Inches, Pt
@@ -24,6 +25,7 @@ from agent_slides.model.types import ComputedNode, Deck, EMU_PER_POINT, Node, Te
 
 BLANK_LAYOUT_INDEX = 6
 HEADING_SIZE_FACTOR = 1.35
+BULLET_MARGIN_STEP_PT = 18.0
 CHART_TYPE_MAP = {
     "bar": XL_CHART_TYPE.BAR_CLUSTERED,
     "column": XL_CHART_TYPE.COLUMN_CLUSTERED,
@@ -92,12 +94,6 @@ def _block_font_size(computed: ComputedNode, block: TextBlock) -> float:
 def _block_lines(block: TextBlock) -> list[str]:
     lines = block.text.splitlines()
     return lines or [""]
-
-
-def _block_text(block: TextBlock, line: str) -> str:
-    if block.type == "bullet":
-        return f"• {line}" if line else "•"
-    return line
 
 
 def _fit_image_to_slot(computed: ComputedNode, image_size_px: tuple[int, int]) -> tuple[float, float, float, float]:
@@ -198,14 +194,35 @@ def _read_layout_bindings(payload: dict[str, Any]) -> dict[str, TemplateLayoutBi
     return bindings
 
 
-def _content_lines(node: Node) -> list[str]:
+def _node_paragraphs(node: Node) -> list[tuple[TextBlock, str]]:
     if isinstance(node.content, str):
-        return node.content.split("\n")
+        block = TextBlock(type="paragraph", text=node.content)
+        return [(block, line) for line in _block_lines(block)]
 
-    lines: list[str] = []
+    paragraphs: list[tuple[TextBlock, str]] = []
     for block in node.content.blocks:
-        lines.extend(_block_text(block, line) for line in _block_lines(block))
-    return lines or [""]
+        paragraphs.extend((block, line) for line in _block_lines(block))
+    return paragraphs or [(TextBlock(type="paragraph", text=""), "")]
+
+
+def _configure_paragraph_bullets(paragraph, block: TextBlock) -> None:
+    pPr = paragraph._p.get_or_add_pPr()
+    pPr.remove_all("a:buNone", "a:buAutoNum", "a:buChar", "a:buBlip")
+
+    if block.type == "bullet":
+        pPr.lvl = block.level
+        buChar = OxmlElement("a:buChar")
+        buChar.set("char", "•")
+        pPr.insert_element_before(buChar, "a:tabLst", "a:defRPr", "a:extLst")
+        pPr.set("marL", str(Pt(BULLET_MARGIN_STEP_PT * (block.level + 1))))
+        pPr.set("indent", str(Pt(-BULLET_MARGIN_STEP_PT)))
+        return
+
+    pPr.lvl = 0
+    for attr_name in ("marL", "indent"):
+        if attr_name in pPr.attrib:
+            del pPr.attrib[attr_name]
+    pPr.insert_element_before(OxmlElement("a:buNone"), "a:tabLst", "a:defRPr", "a:extLst")
 
 
 def _sha256(path: Path) -> str:
@@ -291,10 +308,10 @@ def _fill_placeholder(node: Node, slot_mapping: dict[str, int], slide) -> None:
     text_frame = placeholder.text_frame
     text_frame.clear()
 
-    lines = _content_lines(node)
-    text_frame.paragraphs[0].add_run().text = lines[0]
-    for line in lines[1:]:
-        paragraph = text_frame.add_paragraph()
+    paragraphs = _node_paragraphs(node)
+    for paragraph_index, (block, line) in enumerate(paragraphs):
+        paragraph = text_frame.paragraphs[0] if paragraph_index == 0 else text_frame.add_paragraph()
+        _configure_paragraph_bullets(paragraph, block)
         paragraph.add_run().text = line
 
 
@@ -350,10 +367,10 @@ def _render_text_node(slide_shape_collection: SlideShapes, node: Node, computed:
     for block in blocks:
         for line in _block_lines(block):
             paragraph = text_frame.paragraphs[0] if paragraph_index == 0 else text_frame.add_paragraph()
-            paragraph.level = block.level if block.type == "bullet" else 0
+            _configure_paragraph_bullets(paragraph, block)
 
             run = paragraph.add_run()
-            run.text = _block_text(block, line)
+            run.text = line
             run.font.name = computed.font_family
             run.font.size = Pt(_block_font_size(computed, block))
             run.font.bold = computed.font_bold or block.type == "heading"

--- a/tests/test_pptx_writer.py
+++ b/tests/test_pptx_writer.py
@@ -40,6 +40,7 @@ PNG_1X1 = base64.b64decode(
     "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAusB9Wn0K4sAAAAASUVORK5CYII="
 )
 CHART_NS = {"c": "http://schemas.openxmlformats.org/drawingml/2006/chart"}
+DRAWING_NS = {"a": "http://schemas.openxmlformats.org/drawingml/2006/main"}
 
 
 def build_deck() -> Deck:
@@ -165,6 +166,12 @@ def first_chart_shape(presentation: Presentation):
 def read_chart_xml(path: Path, *, index: int = 1) -> ET.Element:
     with ZipFile(path) as archive:
         payload = archive.read(f"ppt/charts/chart{index}.xml")
+    return ET.fromstring(payload)
+
+
+def read_slide_xml(path: Path, *, index: int = 1) -> ET.Element:
+    with ZipFile(path) as archive:
+        payload = archive.read(f"ppt/slides/slide{index}.xml")
     return ET.fromstring(payload)
 
 
@@ -459,15 +466,29 @@ def test_write_pptx_renders_structured_headings_and_bullets(tmp_path: Path) -> N
 
     presentation = open_presentation(output_path)
     text_frame = presentation.slides[0].shapes[0].text_frame
+    slide_xml = read_slide_xml(output_path)
+    paragraphs = slide_xml.findall(".//a:p", DRAWING_NS)
+    texts = [text.text for text in slide_xml.findall(".//a:t", DRAWING_NS)]
 
     assert [paragraph.text for paragraph in text_frame.paragraphs] == [
         "Highlights",
-        "• First takeaway",
-        "• Nested takeaway",
+        "First takeaway",
+        "Nested takeaway",
     ]
     assert text_frame.paragraphs[0].runs[0].font.size == Pt(27)
     assert text_frame.paragraphs[1].level == 0
     assert text_frame.paragraphs[2].level == 1
+    assert texts == ["Highlights", "First takeaway", "Nested takeaway"]
+    assert paragraphs[0].find("./a:pPr/a:buNone", DRAWING_NS) is not None
+    assert paragraphs[0].find("./a:pPr/a:buChar", DRAWING_NS) is None
+    assert paragraphs[1].find("./a:pPr/a:buChar", DRAWING_NS) is not None
+    assert paragraphs[1].find("./a:pPr/a:buNone", DRAWING_NS) is None
+    assert paragraphs[1].find("./a:pPr", DRAWING_NS).attrib["marL"] == str(Pt(18))
+    assert paragraphs[1].find("./a:pPr", DRAWING_NS).attrib["indent"] == str(Pt(-18))
+    assert paragraphs[2].find("./a:pPr/a:buChar", DRAWING_NS) is not None
+    assert paragraphs[2].find("./a:pPr", DRAWING_NS).attrib["lvl"] == "1"
+    assert paragraphs[2].find("./a:pPr", DRAWING_NS).attrib["marL"] == str(Pt(36))
+    assert paragraphs[2].find("./a:pPr", DRAWING_NS).attrib["indent"] == str(Pt(-18))
 
 def test_write_pptx_renders_image_nodes_with_contain_fit(tmp_path: Path) -> None:
     image_path = write_png(tmp_path / "photo.png", width=200, height=100)


### PR DESCRIPTION
## Summary
- replace fake bullet glyph prefixes with native PowerPoint paragraph bullet XML
- apply the same paragraph bullet handling to template placeholder fills so bullets and non-bullets behave consistently
- tighten PPTX writer coverage to assert `a:buChar`, `a:buNone`, and hanging-indent XML

Closes #150