### PR TITLE
Add content-density reference for create-deck skill

### DIFF
--- a/skills/create-deck/SKILL.md
+++ b/skills/create-deck/SKILL.md
@@ -20,6 +20,7 @@ Load these references at the point they matter:
 - Phase 0: no extra references required beyond asking the questions cleanly
 - Before Phase 1, read `${CLAUDE_SKILL_DIR}/references/storytelling.md`
 - Before locking or overriding layouts in Phase 1 or Phase 2, read `${CLAUDE_SKILL_DIR}/references/layout-selection.md`
+- Before Phase 2, read `${CLAUDE_SKILL_DIR}/references/content-density.md`
 - Before adding a chart in Phase 2, read `${CLAUDE_SKILL_DIR}/references/chart-guide.md`
 - Before Phase 3, read `${CLAUDE_SKILL_DIR}/references/common-mistakes.md`
 
@@ -248,6 +249,7 @@ GAPS: 1 (migration proof)
 ## Phase 2: Build
 
 After the plan is approved, execute it through the CLI.
+Read `${CLAUDE_SKILL_DIR}/references/content-density.md` before building so the slide structures, typography, spacing, and source treatment stay professional instead of defaulting to plain text blocks.
 
 ### Build rules
 

--- a/skills/create-deck/references/content-density.md
+++ b/skills/create-deck/references/content-density.md
@@ -1,0 +1,103 @@
+# Content Density
+
+Use this reference to make content slides feel finished, legible, and consulting-grade before QA. It defines the minimum visual structure and typography discipline that should sit between a strong story and the final anti-pattern sweep.
+
+## 1. Minimum visual structure
+
+Every content slide needs at least one visible organizing device beyond plain text on a blank canvas:
+
+- a structured layout such as `two_col`, `three_col`, `comparison`, or a clearly segmented `title_content` build
+- a data visual such as a chart, table, timeline, or labeled process
+- a visual accent such as a card, rule, highlight band, quote panel, or image block
+
+Plain text on white is not a finished slide. If the body is all text, add at least one structure layer with 12-20pt internal padding, 16-24pt separation from adjacent content, or a 4-6pt accent rule that helps the eye group the message.
+
+## 2. Visual hierarchy
+
+Use four text tiers consistently:
+
+- heading: 18-22pt, bold or semibold, brand color
+- body: 14-16pt, regular weight, dark text
+- secondary labels or annotations: 11-14pt, regular or medium weight, neutral gray
+- source line: 9-10pt, regular weight, light gray
+
+Keep at least a 4pt size step between adjacent tiers. Headings should be visibly dominant over body text, and body text should remain darker than secondary text so the reading order is obvious in under 5 seconds.
+
+## 3. Content area fill
+
+The meaningful content should occupy at least 60% of the usable slide area and usually no more than 85%. A slide that fills less than 60% usually looks unfinished; a slide that fills more than 85% usually feels cramped.
+
+As a working rule:
+
+- keep outer margins around 36-56pt
+- keep major section gaps around 24-36pt
+- leave at least 12-18pt between related blocks
+
+If a slide still feels empty after the core message is present, add structure or emphasis before adding more words.
+
+## 4. Callout numbers
+
+For data-heavy slides, use 1-3 callout numbers as anchors. Set the number at 28-36pt bold, with a short label at 11-13pt below or beside it.
+
+Spacing rules:
+
+- keep 8-12pt between the big number and its label
+- keep 16-24pt between adjacent callout blocks
+- do not use more than 3 large numbers on one slide unless they are arranged as a true table
+
+The callout should summarize the evidence, not duplicate every data point on the slide.
+
+## 5. Card and block patterns
+
+When content is grouped into cards or blocks, make the pattern deliberate:
+
+- use equal widths and equal heights for peer cards
+- keep card padding at 12-18pt on all sides
+- keep the gap between cards at 12-20pt
+- if using an accent bar, make it 4-6pt thick
+- keep text inset from card edges; never let copy touch the border
+
+Cards should clarify grouping, comparison, or sequence. Do not use decorative boxes with inconsistent sizing or random padding.
+
+## 6. Bullet limits
+
+Use no more than 6 bullets on a slide. If the list exceeds 6, split it, convert it into columns, cards, or a table, or move detail to another slide.
+
+Within a bullet area:
+
+- keep bullet text at 14-16pt when it is the main body
+- keep bullet-to-bullet spacing around 6-10pt
+- avoid multi-line bullets unless each line is essential
+
+If the bullets start reading like paragraphs, the slide needs a new structure, not tighter spacing.
+
+## 7. Font size minimums
+
+Do not shrink away a structure problem. Use these minimums:
+
+- main body: 14pt minimum
+- narrow boxes, dense comparison cells, or tight labels: 11pt minimum
+- chart labels, captions, and source cues: 9pt minimum
+
+Treat anything below 14pt as an exception that must be justified by the layout. If multiple body areas need to drop to 11pt, split the slide or change the layout.
+
+## 8. Alignment and spacing
+
+Keep geometry disciplined so the slide reads as one system:
+
+- align related blocks to the same x origin
+- make parallel items share the same top edge and height when they are peers
+- left-align body text and labels unless the slide is a deliberate title or quote moment
+- keep repeated offsets consistent within 2-4pt, not visually approximate
+
+Use spacing rhythm deliberately:
+
+- 24-36pt between title and first body block
+- 12-18pt between a section header and its content
+- 16-24pt between peer columns, cards, or chart-plus-text zones
+
+## 9. Source lines
+
+Every data slide needs a source line at the bottom of the slide. Set it in 9-10pt light gray and keep it inside the content margin, typically 12-18pt above the bottom edge.
+
+The source line should include enough provenance to establish trust, such as publisher or team name, dataset or report label, and date. Keep it short, left-aligned, and visually subordinate to the slide message.

--- a/tests/test_create_deck_skill.py
+++ b/tests/test_create_deck_skill.py
@@ -27,7 +27,8 @@ def test_create_deck_skill_covers_storyline_review_and_qa_outputs() -> None:
     assert "Equal pillars or themes -> `three_col`" in skill_text
     assert "A chart without a takeaway title and annotation" in skill_text
     assert "Deck QA Summary:" in skill_text
-    assert "`references/storytelling.md`" in skill_text
-    assert "`references/layout-selection.md`" in skill_text
-    assert "`references/chart-guide.md`" in skill_text
-    assert "`references/common-mistakes.md`" in skill_text
+    assert "references/storytelling.md" in skill_text
+    assert "references/layout-selection.md" in skill_text
+    assert "references/content-density.md" in skill_text
+    assert "references/chart-guide.md" in skill_text
+    assert "references/common-mistakes.md" in skill_text


### PR DESCRIPTION
## Summary
- add a `content-density.md` reference for create-deck with concrete guidance on structure, hierarchy, density, cards, bullet limits, font minimums, alignment, and source lines
- load the new reference before Phase 2 in `skills/create-deck/SKILL.md`
- update the create-deck skill test to assert the new reference is present

Closes #153