### PR TITLE
Inline preview orchestrator guidance for packaged chat prompt

### DIFF
--- a/src/agent_slides/preview/orchestrator.py
+++ b/src/agent_slides/preview/orchestrator.py
@@ -40,22 +40,18 @@ SYSTEM_PROMPT = """
 You are the deck editing assistant for agent-slides.
 
 - Keep responses short and practical.
-- When the user is creating a new deck, work in three phases: Plan, Build, QA.
-- In Plan, collect missing pre-flight inputs: audience, objective, recommendation, scope, and desired length.
+- When the user is creating a new deck, work in four phases: Phase 0 Pre-flight Questioning, Phase 1 Storyline Review, Phase 2 Build, and Phase 3 QA Review.
+- In Phase 0, collect missing pre-flight inputs. For quick decks of about 5 slides, clarify or infer objective and recommendation first. For strategy decks of 8 or more slides, clarify or infer audience, objective, recommendation, scope, and target deck length.
+- If the user says to just do it, infer the smallest reasonable defaults and state them briefly.
 - Plan new decks with the Pyramid Principle: answer first, then supporting arguments, then evidence.
-- Follow the storytelling guidance in `references/storytelling.md`.
-- Follow the layout guidance in `references/layout-selection.md`.
-- Use `references/chart-guide.md` when planning chart evidence, and use `references/common-mistakes.md` as a manual QA backstop.
 - Use a recommendation-first story: answer first, then 2-4 supporting arguments, then evidence.
 - Use SCQA logic invisibly when shaping a narrative: context, complication, question, answer.
-- For content slides, make the title a short sentence that states the takeaway, and ensure the body proves it.
-- When creating a new deck from a vague request, run a short pre-flight: for quick decks clarify or infer objective and recommendation first; for strategy decks clarify or infer audience, objective, recommendation, scope, and target deck length.
-- If the user says to just do it, infer the smallest reasonable defaults and state them briefly.
+- For content slides, make the title a short sentence that states the takeaway, ensure the body proves it, and avoid bullet overload.
 - Before mutating a new deck, propose a storyline with the title, the core answer, and 2-4 supporting arguments with slide coverage.
-- Review the storyline section by section, close message gaps before building, and prefer adding a missing slide over leaving an unsupported claim.
-- Choose layouts isomorphically: equal peers should look equal, comparisons should be side by side, single narratives should read linearly, and quotes should be used deliberately.
+- Review the storyline section by section, check message coverage, close gaps before building, and prefer adding a missing slide over leaving an unsupported claim.
+- Choose layouts isomorphically: equal pillars or themes should use `three_col`; two contrasting approaches should use `two_col` or `comparison`; structured comparisons with headers should use `comparison`; sequential narratives or one claim with proof should use `title_content`; quotes should be used deliberately.
 - Avoid repeating the same content layout 3 or more slides in a row when the deck is longer than 6 slides.
-- For charts, use an action-title takeaway and include an annotation or callout for the key insight.
+- For charts, use an action-title takeaway, include an annotation or callout for the key insight, and add source lines for data claims when the user provides them.
 - Prefer `slide_add` with `auto_layout: true` unless the user clearly asks for a specific layout.
 - Start decks with a title slide when creating a new presentation.
 - End completed decks with a closing slide when the narrative calls for a clear takeaway.

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -12,11 +12,12 @@ from agent_slides.preview import orchestrator as orchestrator_module
 from agent_slides.preview.orchestrator import DeckOrchestrator, SYSTEM_PROMPT
 
 
-def test_orchestrator_system_prompt_references_storytelling_guide() -> None:
-    assert "references/storytelling.md" in SYSTEM_PROMPT
-    assert "references/layout-selection.md" in SYSTEM_PROMPT
-    assert "references/chart-guide.md" in SYSTEM_PROMPT
-    assert "references/common-mistakes.md" in SYSTEM_PROMPT
+def test_orchestrator_system_prompt_is_self_contained() -> None:
+    assert "references/" not in SYSTEM_PROMPT
+    assert "Phase 0 Pre-flight Questioning" in SYSTEM_PROMPT
+    assert "Phase 1 Storyline Review" in SYSTEM_PROMPT
+    assert "Phase 2 Build" in SYSTEM_PROMPT
+    assert "Phase 3 QA Review" in SYSTEM_PROMPT
     assert "recommendation-first story" in SYSTEM_PROMPT
     assert "SCQA" in SYSTEM_PROMPT
     assert "objective and recommendation first" in SYSTEM_PROMPT
@@ -24,6 +25,8 @@ def test_orchestrator_system_prompt_references_storytelling_guide() -> None:
     assert "core answer, and 2-4 supporting arguments with slide coverage" in SYSTEM_PROMPT
     assert "section by section" in SYSTEM_PROMPT
     assert "Choose layouts isomorphically" in SYSTEM_PROMPT
+    assert "equal pillars or themes should use `three_col`" in SYSTEM_PROMPT
+    assert "bullet overload" in SYSTEM_PROMPT
     assert "chart clarity" in SYSTEM_PROMPT
 
 
@@ -82,7 +85,10 @@ def test_orchestrator_executes_tool_calls_and_preserves_conversation_history(
     deck = read_deck(str(deck_path))
     assert len(deck.slides) == 1
     assert api_calls[0]["messages"] == [{"role": "user", "content": "Create the first slide."}]
-    assert "three phases: Plan, Build, QA" in api_calls[0]["system"]
+    assert "Phase 0 Pre-flight Questioning" in api_calls[0]["system"]
+    assert "Phase 1 Storyline Review" in api_calls[0]["system"]
+    assert "Phase 2 Build" in api_calls[0]["system"]
+    assert "Phase 3 QA Review" in api_calls[0]["system"]
     assert "Pyramid Principle" in api_calls[0]["system"]
     assert "action title" in api_calls[0]["system"]
     assert {tool["name"] for tool in api_calls[0]["tools"]} == {


### PR DESCRIPTION
## Summary
- inline the preview chat orchestrator guidance so the runtime prompt no longer references repo-only `skills/create-deck/references/*` files
- preserve the deck planning/storytelling/layout/chart guidance inside the shipped system prompt
- update orchestrator tests to assert the new self-contained prompt contract

## Validation
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest -q tests/test_orchestrator.py`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest -q tests/test_create_deck_skill.py`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest -q tests/test_e2e_chat.py`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest -q`

Closes #162