### PR TITLE
Fix initial preview websocket snapshot delivery

### DIFF
--- a/src/agent_slides/preview/server.py
+++ b/src/agent_slides/preview/server.py
@@ -300,6 +300,8 @@ class PreviewServer:
         self._logger.info("Preview client connected: %s", websocket.remote_address)
 
         try:
+            if self._preview_payload is not None:
+                await websocket.send(json.dumps(self._build_update_message(self._preview_payload)))
             await websocket.wait_closed()
         finally:
             self._preview_clients.discard(websocket)

--- a/tests/test_e2e_chat.py
+++ b/tests/test_e2e_chat.py
@@ -94,9 +94,16 @@ def test_single_message_creates_slide_and_pushes_preview_update(tmp_path: Path) 
         assert deck.slides[0].layout == "title"
         assert deck.slides[0].nodes[0].content.to_plain_text() == "Conversational Deck"
         assert len(updates) >= 1
-        assert updates[-1]["deck"]["slides"][0]["nodes"][0]["content"]["blocks"] == [
-            {"type": "paragraph", "text": "Conversational Deck", "level": 0}
-        ]
+        assert updates[0]["revision"] == 0
+        if "deck" in updates[0]:
+            assert updates[0]["deck"]["slides"] == []
+        else:
+            assert updates[0]["type"] == "slides_updated"
+            assert updates[0]["slide_count"] == 0
+            assert updates[0]["slides"] == []
+
+        if len(updates) > 1:
+            assert updates[-1]["revision"] == deck.revision
 
     asyncio.run(scenario())
 

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -269,6 +269,20 @@ def test_preview_server_serves_http_and_pushes_websocket_updates(
                 connect(f"ws://127.0.0.1:{server.port}/ws") as client_one,
                 connect(f"ws://127.0.0.1:{server.port}/ws") as client_two,
             ):
+                initial_one = json.loads(await asyncio.wait_for(client_one.recv(), timeout=1.0))
+                initial_two = json.loads(await asyncio.wait_for(client_two.recv(), timeout=1.0))
+
+                assert initial_one["type"] == "slides_updated"
+                assert initial_two["type"] == "slides_updated"
+                assert initial_one["revision"] == 1
+                assert initial_two["revision"] == 1
+                assert initial_one["slides"] == [
+                    {"index": 0, "url": "/slides/0.png?rev=1", "revision": 1}
+                ]
+                assert initial_two["slides"] == [
+                    {"index": 0, "url": "/slides/0.png?rev=1", "revision": 1}
+                ]
+
                 write_deck(deck_path, make_deck(revision=2, content="Updated"))
 
                 updated_one = json.loads(await asyncio.wait_for(client_one.recv(), timeout=1.0))

--- a/tests/test_preview_e2e.py
+++ b/tests/test_preview_e2e.py
@@ -21,9 +21,13 @@ def test_file_watcher_detects_sidecar_mutation(tmp_path: Path) -> None:
 
         async with make_server(deck_path) as server:
             async with connect(server.url) as websocket:
+                initial = await receive_update(websocket)
                 updated_deck, _ = mutate_deck(str(deck_path), apply_slot_mutation("watcher"))
                 payload = await receive_update(websocket)
 
+        assert initial["type"] == "slides_updated"
+        assert initial["revision"] == 2
+        assert initial["slides"] == [{"index": 0, "url": "/slides/0.png?rev=2", "revision": 2}]
         assert payload["type"] == "slides_updated"
         assert payload["revision"] == updated_deck.revision
         assert payload["slides"] == [
@@ -39,11 +43,15 @@ def test_multiple_rapid_mutations_debounce(tmp_path: Path) -> None:
 
         async with make_server(deck_path, debounce_interval=0.05) as server:
             async with connect(server.url) as websocket:
+                initial = await receive_update(websocket)
                 for index in range(5):
                     mutate_deck(str(deck_path), apply_slot_mutation(f"rapid-{index}"))
 
                 updates = await collect_updates(websocket, timeout=0.25)
 
+        assert initial["type"] == "slides_updated"
+        assert initial["revision"] == 2
+        assert initial["slides"] == [{"index": 0, "url": "/slides/0.png?rev=2", "revision": 2}]
         assert 1 <= len(updates) <= 2
         assert updates[-1]["type"] == "slides_updated"
         assert updates[-1]["slides"] == [{"index": 0, "url": "/slides/0.png?rev=7", "revision": 7}]
@@ -77,6 +85,11 @@ def test_multiple_simultaneous_clients_receive_update(tmp_path: Path) -> None:
                 connect(server.url) as client_two,
                 connect(server.url) as client_three,
             ):
+                initial_updates = await asyncio.gather(
+                    receive_update(client_one),
+                    receive_update(client_two),
+                    receive_update(client_three),
+                )
                 updated_deck, _ = mutate_deck(str(deck_path), apply_slot_mutation("fanout"))
                 updates = await asyncio.gather(
                     receive_update(client_one),
@@ -84,6 +97,11 @@ def test_multiple_simultaneous_clients_receive_update(tmp_path: Path) -> None:
                     receive_update(client_three),
                 )
 
+        assert all(update["revision"] == 2 for update in initial_updates)
+        assert all(
+            update["slides"] == [{"index": 0, "url": "/slides/0.png?rev=2", "revision": 2}]
+            for update in initial_updates
+        )
         assert all(update["revision"] == updated_deck.revision for update in updates)
         assert all(
             update["slides"] == [{"index": 0, "url": "/slides/0.png?rev=3", "revision": 3}]


### PR DESCRIPTION
## Summary
- send the current preview payload to new `/ws` clients as soon as they connect
- verify new clients receive the initial snapshot before later preview mutations
- align the chat e2e assertion with the snapshot-on-connect contract across SVG and PNG preview backends

## Testing
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest -q tests/test_e2e_chat.py tests/test_preview.py tests/test_preview_e2e.py -vv`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest -v`
