### PR TITLE
Layout engine v2 step 1: type ladders + better text measurement

### DIFF
--- a/src/agent_slides/config/design_rules/default.yaml
+++ b/src/agent_slides/config/design_rules/default.yaml
@@ -16,6 +16,12 @@ overflow_policy:
 deck_structure:
   recommend_title_slide: true
   recommend_closing_slide: true
+normalize_font_sizes: true
+type_ladders:
+  heading: [36, 32, 28, 24]
+  body: [18, 16, 14, 12, 10]
+  quote: [28, 24, 20, 18]
+  attribution: [16, 14, 12, 10]
 layout_hints:
   max_bullets_for_single_column: 5
   equal_length_threshold: 0.4

--- a/src/agent_slides/engine/reflow.py
+++ b/src/agent_slides/engine/reflow.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
+from math import isclose
 
 from agent_slides.errors import AgentSlidesError, INVALID_SLOT
 from agent_slides.engine.slide_revisions import resolve_slide_revision
 from agent_slides.engine.text_fit import fit_text
 from agent_slides.model import Deck, LayoutDef, Slide
+from agent_slides.model.design_rules import DesignRules, load_design_rules
 from agent_slides.model.layout_provider import BuiltinLayoutProvider, LayoutProvider
 from agent_slides.model.layouts import (
     SLIDE_HEIGHT_PT,
@@ -79,7 +81,78 @@ def _text_fit_rules(layout_def: LayoutDef, node: Node) -> TextFitting:
     return layout_def.text_fitting[slot.role]
 
 
-def _reflow_slide(slide: Slide, layout_def: LayoutDef, theme: Theme, *, revision: int) -> None:
+def _resolve_text_ladder(
+    fit_rules: TextFitting,
+    role: str,
+    design_rules: DesignRules | None,
+) -> list[float] | None:
+    if fit_rules.ladder:
+        return list(fit_rules.ladder)
+    if design_rules is None:
+        return None
+    configured = design_rules.type_ladders.get(role, [])
+    ladder = [size for size in configured if fit_rules.min_size <= size <= fit_rules.default_size]
+    return ladder or None
+
+
+def _normalize_deck_font_sizes(deck: Deck, provider: LayoutProvider, design_rules: DesignRules) -> None:
+    if not design_rules.normalize_font_sizes:
+        return
+
+    role_minimums: dict[str, float] = {}
+    entries: list[tuple[Node, ComputedNode, str, TextFitting, list[float] | None]] = []
+
+    for slide in deck.slides:
+        layout_def = provider.get_layout(slide.layout)
+        for node in slide.nodes:
+            if node.type != "text" or node.slot_binding is None:
+                continue
+            if node.node_id not in slide.computed:
+                continue
+
+            slot = layout_def.slots[node.slot_binding]
+            if slot.role == "image":
+                continue
+
+            computed = slide.computed[node.node_id]
+            fit_rules = provider.get_text_fitting(slide.layout, slot.role)
+            ladder = _resolve_text_ladder(fit_rules, slot.role, design_rules)
+            entries.append((node, computed, slot.role, fit_rules, ladder))
+            current = role_minimums.get(slot.role)
+            if current is None or computed.font_size_pt < current:
+                role_minimums[slot.role] = computed.font_size_pt
+
+    for node, computed, role, fit_rules, ladder in entries:
+        target_size = role_minimums[role]
+        if computed.font_size_pt <= target_size:
+            continue
+        if ladder is not None and not any(isclose(size, target_size, rel_tol=0.0, abs_tol=1e-6) for size in ladder):
+            continue
+
+        normalized_size, overflow = fit_text(
+            text=node.content,
+            width=computed.width,
+            height=computed.height,
+            default_size=fit_rules.default_size,
+            min_size=fit_rules.min_size,
+            role=role,
+            font_family=computed.font_family,
+            ladder=[target_size],
+        )
+        if overflow or not isclose(normalized_size, target_size, rel_tol=0.0, abs_tol=1e-6):
+            continue
+        computed.font_size_pt = normalized_size
+        computed.text_overflow = False
+
+
+def _reflow_slide(
+    slide: Slide,
+    layout_def: LayoutDef,
+    theme: Theme,
+    *,
+    revision: int,
+    design_rules: DesignRules | None = None,
+) -> None:
     computed: dict[str, ComputedNode] = {}
     slide.revision = revision
 
@@ -134,12 +207,16 @@ def _reflow_slide(slide: Slide, layout_def: LayoutDef, theme: Theme, *, revision
 
         style = resolve_style(theme, slot.role)
         fit_rules = _text_fit_rules(layout_def, node)
+        ladder = _resolve_text_ladder(fit_rules, slot.role, design_rules)
         font_size_pt, text_overflow = fit_text(
             text=node.content,
             width=width,
             height=height,
             default_size=fit_rules.default_size,
             min_size=fit_rules.min_size,
+            role=slot.role,
+            font_family=str(style["font_family"]),
+            ladder=ladder,
         )
 
         computed[node.node_id] = ComputedNode(
@@ -178,6 +255,7 @@ def reflow_deck(
 
     active_provider = provider or BuiltinLayoutProvider()
     theme = getattr(active_provider, "theme", None) or load_theme(deck.theme)
+    design_rules = load_design_rules(deck.design_rules)
     for slide in deck.slides:
         layout_getter = active_provider.get_layout
         slide_revision = resolve_slide_revision(
@@ -185,7 +263,14 @@ def reflow_deck(
             deck_revision=deck.revision,
             previous_slide_signatures=previous_slide_signatures,
         )
-        _reflow_slide(slide, layout_getter(slide.layout), theme, revision=slide_revision)
+        _reflow_slide(
+            slide,
+            layout_getter(slide.layout),
+            theme,
+            revision=slide_revision,
+            design_rules=design_rules,
+        )
+    _normalize_deck_font_sizes(deck, active_provider, design_rules)
 
 
 def rebind_slots(

--- a/src/agent_slides/engine/template_reflow.py
+++ b/src/agent_slides/engine/template_reflow.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 from agent_slides.errors import AgentSlidesError, INVALID_SLOT
 from agent_slides.engine.slide_revisions import resolve_slide_revision
+from agent_slides.engine.reflow import _normalize_deck_font_sizes, _resolve_text_ladder
 from agent_slides.engine.text_fit import fit_text
+from agent_slides.model.design_rules import load_design_rules
 from agent_slides.model.layout_provider import TemplateLayoutRegistry
 from agent_slides.model.themes import resolve_style
 from agent_slides.model.types import ComputedNode, Deck
@@ -19,6 +21,7 @@ def template_reflow(
     """Populate computed nodes from template placeholder bounds and theme."""
 
     theme = registry.theme
+    design_rules = load_design_rules(deck.design_rules)
     for slide in deck.slides:
         slide_revision = resolve_slide_revision(
             slide,
@@ -71,12 +74,16 @@ def template_reflow(
                 continue
 
             fit_rules = registry.get_text_fitting(slide.layout, slot.role)
+            ladder = _resolve_text_ladder(fit_rules, slot.role, design_rules)
             font_size_pt, text_overflow = fit_text(
                 text=node.content,
                 width=width,
                 height=height,
                 default_size=fit_rules.default_size,
                 min_size=fit_rules.min_size,
+                role=slot.role,
+                font_family=str(style["font_family"]),
+                ladder=ladder,
             )
             computed[node.node_id] = ComputedNode(
                 x=x,
@@ -95,3 +102,5 @@ def template_reflow(
             )
 
         slide.computed = computed
+
+    _normalize_deck_font_sizes(deck, registry, design_rules)

--- a/src/agent_slides/engine/text_fit.py
+++ b/src/agent_slides/engine/text_fit.py
@@ -4,11 +4,31 @@ from __future__ import annotations
 
 from math import ceil
 
+from PIL import ImageFont
+
 from agent_slides.model.types import NodeContent, TextBlock
 
-AVG_CHAR_WIDTH_FACTOR = 0.6
+TYPE_LADDERS = {
+    "heading": [36.0, 32.0, 28.0, 24.0],
+    "body": [18.0, 16.0, 14.0, 12.0, 10.0],
+    "quote": [28.0, 24.0, 20.0, 18.0],
+    "attribution": [16.0, 14.0, 12.0, 10.0],
+}
+FONT_WIDTH_FACTORS = {
+    "calibri": 0.52,
+    "arial": 0.55,
+    "georgia": 0.56,
+    "times new roman": 0.50,
+    "helvetica": 0.54,
+}
+DEFAULT_WIDTH_FACTOR = 0.55
+ROLE_STEP_PT = {
+    "heading": 4.0,
+    "body": 2.0,
+    "quote": 4.0,
+    "attribution": 2.0,
+}
 LINE_HEIGHT_FACTOR = 1.2
-SHRINK_STEP_PT = 2.0
 BLOCK_SPACING_FACTOR = 0.3
 HEADING_SIZE_FACTOR = 1.35
 HEADING_LINE_HEIGHT_FACTOR = 1.1
@@ -20,33 +40,34 @@ def fit_text(
     text: str | NodeContent,
     width: float,
     height: float,
-    default_size: float,
+    default_size: float | None = None,
     min_size: float = 10.0,
+    role: str = "body",
+    *,
+    font_family: str | None = None,
+    ladder: list[float] | None = None,
+    use_precise: bool = False,
 ) -> tuple[float, bool]:
     """Estimate a font size that fits text into a bounded area."""
     content = _normalize_content(text)
+    sizes = _resolve_ladder(role, default_size=default_size, min_size=min_size, ladder=ladder)
+    largest_size = sizes[0]
+    smallest_size = sizes[-1]
 
     if width <= 0 or height <= 0:
-        return min_size, True
+        return smallest_size, True
 
     if content.is_empty():
-        return default_size, False
+        return largest_size, False
 
     if len(content.to_plain_text()) == 1:
-        return default_size, False
+        return largest_size, False
 
-    font_size = default_size
-
-    while font_size > min_size:
-        if _fits(content, width, height, font_size):
+    for font_size in sizes:
+        if _fits(content, width, height, font_size, font_family=font_family, use_precise=use_precise):
             return font_size, False
 
-        font_size -= SHRINK_STEP_PT
-
-    if _fits(content, width, height, min_size):
-        return min_size, False
-
-    return min_size, True
+    return smallest_size, True
 
 
 def _normalize_content(text: str | NodeContent) -> NodeContent:
@@ -67,37 +88,189 @@ def _line_height_factor(block: TextBlock) -> float:
     return LINE_HEIGHT_FACTOR
 
 
-def _block_width(width: float, block: TextBlock, font_size: float) -> float:
+def _normalize_font_family(font_family: str | None) -> str:
+    if not font_family:
+        return ""
+    return font_family.strip().casefold()
+
+
+def _width_factor(font_family: str | None) -> float:
+    return FONT_WIDTH_FACTORS.get(_normalize_font_family(font_family), DEFAULT_WIDTH_FACTOR)
+
+
+def _sanitize_ladder(values: list[float]) -> list[float]:
+    seen: set[float] = set()
+    sanitized: list[float] = []
+    for value in values:
+        size = float(value)
+        if size <= 0:
+            continue
+        if size in seen:
+            continue
+        seen.add(size)
+        sanitized.append(size)
+    return sorted(sanitized, reverse=True)
+
+
+def _role_step(role: str) -> float:
+    return ROLE_STEP_PT.get(role, 2.0)
+
+
+def _build_role_ladder(role: str, *, default_size: float, min_size: float) -> list[float]:
+    step = _role_step(role)
+    size = float(default_size)
+    ladder = [size]
+    while size - step > min_size:
+        size -= step
+        ladder.append(size)
+    if ladder[-1] != float(min_size):
+        ladder.append(float(min_size))
+    return _sanitize_ladder(ladder)
+
+
+def _resolve_ladder(
+    role: str,
+    *,
+    default_size: float | None,
+    min_size: float,
+    ladder: list[float] | None,
+) -> list[float]:
+    if ladder is not None:
+        sanitized = _sanitize_ladder(ladder)
+        if sanitized:
+            return sanitized
+
+    if default_size is not None:
+        return _build_role_ladder(role, default_size=default_size, min_size=min_size)
+
+    configured = TYPE_LADDERS.get(role)
+    if configured:
+        return list(configured)
+
+    return [float(min_size)]
+
+
+def _block_width(width: float, block: TextBlock, font_size: float, *, font_family: str | None) -> float:
     available_width = width
     if block.type == "bullet":
         available_width -= block.level * BULLET_INDENT_PT
-        available_width -= BULLET_GLYPH_WIDTH_CHARS * AVG_CHAR_WIDTH_FACTOR * font_size
+        available_width -= BULLET_GLYPH_WIDTH_CHARS * _width_factor(font_family) * font_size
     return max(available_width, 1.0)
 
 
-def _estimate_lines(text: str, width: float, font_size: float) -> int:
-    avg_char_width = AVG_CHAR_WIDTH_FACTOR * font_size
+def _estimate_lines(text: str, width: float, font_size: float, *, font_family: str | None) -> int:
+    avg_char_width = _width_factor(font_family) * font_size
 
     if avg_char_width <= 0:
         return max(len(text), 1)
 
     chars_per_line = width / avg_char_width
 
-    # Treat sub-character widths as one character per line to avoid division blowups.
     if chars_per_line < 1:
         return max(len(text), 1)
 
     return max(sum(ceil(len(line) / chars_per_line) or 1 for line in text.splitlines()), 1)
 
 
-def _fits(content: NodeContent, width: float, height: float, font_size: float) -> bool:
+def _fallback_font_name(font_family: str | None) -> str:
+    lowered = _normalize_font_family(font_family)
+    if lowered in {"georgia", "times new roman"}:
+        return "DejaVuSerif.ttf"
+    return "DejaVuSans.ttf"
+
+
+def _load_precise_font(font_family: str | None, size: float) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    requested_size = max(int(round(size)), 1)
+    candidates: list[str] = []
+    if font_family and font_family.strip():
+        candidates.append(font_family.strip())
+    candidates.append(_fallback_font_name(font_family))
+
+    for candidate in candidates:
+        try:
+            return ImageFont.truetype(candidate, requested_size)
+        except OSError:
+            continue
+
+    return ImageFont.load_default()
+
+
+def _measure_precise_width(text: str, font: ImageFont.ImageFont) -> float:
+    if text == "":
+        return 0.0
+    return float(font.getlength(text))
+
+
+def _measure_precise_line_height(font: ImageFont.ImageFont) -> float:
+    left, top, right, bottom = font.getbbox("Ag")
+    height = float(bottom - top)
+    if height > 0:
+        return height
+    return float(getattr(font, "size", 0) or 1.0)
+
+
+def _wrap_precise_line(text: str, width: float, font: ImageFont.ImageFont) -> list[str]:
+    if text == "":
+        return [""]
+
+    lines: list[str] = []
+    remaining = text
+    while remaining:
+        if _measure_precise_width(remaining, font) <= width:
+            lines.append(remaining)
+            break
+
+        last_fit = 0
+        last_whitespace = 0
+        for index in range(1, len(remaining) + 1):
+            chunk = remaining[:index]
+            if _measure_precise_width(chunk, font) > width:
+                break
+            last_fit = index
+            if chunk[-1].isspace():
+                last_whitespace = index
+
+        split_at = last_whitespace or last_fit or 1
+        line = remaining[:split_at].rstrip() or remaining[:split_at]
+        lines.append(line)
+        remaining = remaining[split_at:].lstrip()
+
+    return lines or [""]
+
+
+def _estimate_lines_precise(text: str, width: float, font: ImageFont.ImageFont) -> tuple[int, float]:
+    paragraphs = text.splitlines() or [""]
+    lines = 0
+    max_height = 0.0
+    for paragraph in paragraphs:
+        wrapped = _wrap_precise_line(paragraph, width, font)
+        lines += len(wrapped)
+        max_height = max(max_height, _measure_precise_line_height(font))
+    return max(lines, 1), max(max_height, 1.0)
+
+
+def _fits(
+    content: NodeContent,
+    width: float,
+    height: float,
+    font_size: float,
+    *,
+    font_family: str | None,
+    use_precise: bool,
+) -> bool:
     lines_height = 0.0
     blocks = content.blocks or [TextBlock(type="paragraph", text="")]
     for index, block in enumerate(blocks):
         block_font_size = font_size * _font_size_factor(block)
-        block_width = _block_width(width, block, block_font_size)
-        lines = _estimate_lines(block.text, block_width, block_font_size)
-        lines_height += lines * block_font_size * _line_height_factor(block)
+        block_width = _block_width(width, block, block_font_size, font_family=font_family)
+        if use_precise:
+            font = _load_precise_font(font_family, block_font_size)
+            lines, line_height = _estimate_lines_precise(block.text, block_width, font)
+        else:
+            lines = _estimate_lines(block.text, block_width, block_font_size, font_family=font_family)
+            line_height = block_font_size
+
+        lines_height += lines * line_height * _line_height_factor(block)
         if index < len(blocks) - 1:
             lines_height += font_size * BLOCK_SPACING_FACTOR
 

--- a/src/agent_slides/model/design_rules.py
+++ b/src/agent_slides/model/design_rules.py
@@ -7,9 +7,16 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, Field, ValidationError
+from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from agent_slides.errors import AgentSlidesError, FILE_NOT_FOUND, SCHEMA_ERROR
+
+DEFAULT_TYPE_LADDERS = {
+    "heading": [36.0, 32.0, 28.0, 24.0],
+    "body": [18.0, 16.0, 14.0, 12.0, 10.0],
+    "quote": [28.0, 24.0, 20.0, 18.0],
+    "attribution": [16.0, 14.0, 12.0, 10.0],
+}
 
 
 class ContentLimits(BaseModel):
@@ -65,6 +72,23 @@ class DesignRules(BaseModel):
     overflow_policy: OverflowPolicy
     deck_structure: DeckStructureRules
     layout_hints: LayoutHints = Field(default_factory=LayoutHints)
+    normalize_font_sizes: bool = True
+    type_ladders: dict[str, list[float]] = Field(
+        default_factory=lambda: {role: list(sizes) for role, sizes in DEFAULT_TYPE_LADDERS.items()}
+    )
+
+    @field_validator("type_ladders")
+    @classmethod
+    def validate_type_ladders(cls, value: dict[str, list[float]]) -> dict[str, list[float]]:
+        normalized: dict[str, list[float]] = {}
+        for role, sizes in value.items():
+            if not sizes:
+                raise ValueError(f"type ladder for role '{role}' cannot be empty")
+            ladder = [float(size) for size in sizes]
+            if any(size <= 0 for size in ladder):
+                raise ValueError(f"type ladder for role '{role}' must contain positive sizes")
+            normalized[role] = ladder
+        return normalized
 
 
 def _design_rules_dir() -> resources.abc.Traversable:

--- a/src/agent_slides/model/types.py
+++ b/src/agent_slides/model/types.py
@@ -381,6 +381,7 @@ class GridDef(AgentSlidesModel):
 class TextFitting(AgentSlidesModel):
     default_size: float
     min_size: float = 10.0
+    ladder: list[float] | None = None
 
 
 class LayoutDef(AgentSlidesModel):

--- a/tests/test_design_rules.py
+++ b/tests/test_design_rules.py
@@ -16,6 +16,8 @@ def test_load_default_design_rules() -> None:
     assert rules.name == "default"
     assert rules.content_limits.max_bullets_per_slide == 6
     assert rules.overflow_policy.strategy == "shrink"
+    assert rules.normalize_font_sizes is True
+    assert rules.type_ladders["heading"] == [36.0, 32.0, 28.0, 24.0]
     assert rules.layout_hints.max_bullets_for_single_column == 5
     assert rules.layout_hints.equal_length_threshold == 0.4
     assert rules.layout_hints.short_text_threshold == 10

--- a/tests/test_reflow.py
+++ b/tests/test_reflow.py
@@ -4,8 +4,9 @@ from pathlib import Path
 
 import pytest
 
-from agent_slides.engine.reflow import reflow_slide
-from agent_slides.model import Node, Slide, get_layout
+import agent_slides.engine.reflow as reflow_module
+from agent_slides.engine.reflow import reflow_deck, reflow_slide
+from agent_slides.model import Counters, Deck, Node, Slide, get_layout
 from agent_slides.model.themes import load_theme
 
 
@@ -105,3 +106,46 @@ def test_reflow_image_nodes_still_skip_text_fitting(tmp_path: Path) -> None:
     assert image.font_size_pt == 0.0
     assert image.content_type == "image"
     assert image.text_overflow is False
+
+
+def test_reflow_deck_normalizes_font_sizes_by_role(monkeypatch: pytest.MonkeyPatch) -> None:
+    deck = Deck(
+        deck_id="deck-normalized",
+        theme="default",
+        design_rules="default",
+        slides=[
+            Slide(
+                slide_id="s-1",
+                layout="title_content",
+                nodes=[
+                    Node(node_id="n-1", slot_binding="heading", type="text", content="Short heading"),
+                    Node(node_id="n-2", slot_binding="body", type="text", content="Short body"),
+                ],
+            ),
+            Slide(
+                slide_id="s-2",
+                layout="title_content",
+                nodes=[
+                    Node(node_id="n-3", slot_binding="heading", type="text", content="Long heading"),
+                    Node(node_id="n-4", slot_binding="body", type="text", content="Long body"),
+                ],
+            ),
+        ],
+        counters=Counters(slides=2, nodes=4),
+    )
+
+    def fake_fit_text(*, text, width, height, default_size, min_size, role, font_family=None, ladder=None, use_precise=False):
+        assert font_family == "Calibri"
+        if ladder == [24.0]:
+            return (24.0, False)
+        if role == "heading":
+            return (32.0, False) if text.to_plain_text() == "Short heading" else (24.0, False)
+        return (18.0, False)
+
+    monkeypatch.setattr(reflow_module, "fit_text", fake_fit_text)
+
+    reflow_deck(deck)
+
+    assert deck.slides[0].computed["n-1"].font_size_pt == 24.0
+    assert deck.slides[1].computed["n-3"].font_size_pt == 24.0
+    assert deck.slides[0].computed["n-2"].font_size_pt == 18.0

--- a/tests/test_template_reflow.py
+++ b/tests/test_template_reflow.py
@@ -77,10 +77,22 @@ def test_template_reflow_uses_manifest_bounds_theme_and_text_fitting(
     image_path = tmp_path / "hero.png"
     image_path.write_bytes(b"png")
 
-    fit_calls: list[tuple[float, float, float, float]] = []
+    fit_calls: list[tuple[float, float, float, float, str, str, list[float] | None]] = []
 
-    def fake_fit_text(*, text, width: float, height: float, default_size: float, min_size: float):
-        fit_calls.append((width, height, default_size, min_size))
+    def fake_fit_text(
+        *,
+        text,
+        width: float,
+        height: float,
+        default_size: float,
+        min_size: float,
+        role: str,
+        font_family: str | None = None,
+        ladder: list[float] | None = None,
+        use_precise: bool = False,
+    ):
+        assert use_precise is False
+        fit_calls.append((width, height, default_size, min_size, role, font_family or "", ladder))
         return (26.0, False) if default_size == 32.0 else (14.0, True)
 
     monkeypatch.setattr(template_reflow_module, "fit_text", fake_fit_text)
@@ -138,8 +150,8 @@ def test_template_reflow_uses_manifest_bounds_theme_and_text_fitting(
     assert image.color == "#101010"
 
     assert fit_calls == [
-        (280.0, 48.0, 32.0, 24.0),
-        (260.0, 160.0, 18.0, 10.0),
+        (280.0, 48.0, 32.0, 24.0, "heading", "Aptos Display", [32.0, 28.0, 24.0]),
+        (260.0, 160.0, 18.0, 10.0, "body", "Aptos", [18.0, 16.0, 14.0, 12.0, 10.0]),
     ]
 
 

--- a/tests/test_text_fit.py
+++ b/tests/test_text_fit.py
@@ -1,44 +1,76 @@
 from __future__ import annotations
 
+from PIL import ImageFont
+
 from agent_slides.engine.text_fit import fit_text
 from agent_slides.model.types import NodeContent, TextBlock
 
 
 def test_short_text_fits_at_default_size() -> None:
-    assert fit_text("Hello world", width=200, height=80, default_size=32) == (32, False)
+    assert fit_text("Hello world", width=200, height=80, default_size=32, role="heading") == (32, False)
 
 
-def test_medium_text_shrinks_until_it_fits() -> None:
-    font_size, overflowed = fit_text("A" * 60, width=180, height=100, default_size=32)
+def test_body_text_uses_discrete_ladder_steps() -> None:
+    font_size, overflowed = fit_text("A" * 60, width=96, height=140, default_size=18, role="body")
 
-    assert font_size == 20
+    assert font_size == 16
     assert overflowed is False
 
 
 def test_long_text_overflows_at_min_size() -> None:
-    assert fit_text("A" * 500, width=120, height=60, default_size=24) == (10.0, True)
+    assert fit_text("A" * 500, width=120, height=60, default_size=24, role="body") == (10.0, True)
 
 
-def test_empty_text_returns_default_size() -> None:
-    assert fit_text("", width=120, height=60, default_size=24) == (24, False)
+def test_empty_text_returns_largest_ladder_size() -> None:
+    assert fit_text("", width=120, height=60, role="quote") == (28.0, False)
 
 
 def test_single_character_returns_default_size() -> None:
-    assert fit_text("A", width=20, height=20, default_size=32) == (32, False)
+    assert fit_text("A", width=20, height=20, default_size=32, role="heading") == (32, False)
 
 
 def test_very_long_text_shrinks_to_min_size_and_overflows() -> None:
-    assert fit_text("A" * 10_000, width=500, height=200, default_size=24) == (10.0, True)
+    assert fit_text("A" * 10_000, width=500, height=200, default_size=24, role="body") == (10.0, True)
 
 
-def test_zero_width_returns_min_size_with_overflow() -> None:
-    assert fit_text("Hello", width=0, height=60, default_size=24) == (10.0, True)
+def test_zero_width_returns_smallest_ladder_size_with_overflow() -> None:
+    assert fit_text("Hello", width=0, height=60, default_size=24, role="body") == (10.0, True)
 
 
-def test_shrinking_happens_in_two_point_steps() -> None:
-    font_size, overflowed = fit_text("A" * 50, width=180, height=170, default_size=32)
+def test_font_family_width_factors_change_selected_size() -> None:
+    calibri_size, calibri_overflow = fit_text(
+        "A" * 60,
+        width=96,
+        height=140,
+        default_size=18,
+        role="body",
+        font_family="Calibri",
+    )
+    georgia_size, georgia_overflow = fit_text(
+        "A" * 60,
+        width=96,
+        height=140,
+        default_size=18,
+        role="body",
+        font_family="Georgia",
+    )
 
-    assert font_size == 28
+    assert (calibri_size, calibri_overflow) == (18, False)
+    assert (georgia_size, georgia_overflow) == (16, False)
+
+
+def test_custom_ladder_overrides_default_and_minimum_sizes() -> None:
+    font_size, overflowed = fit_text(
+        "A" * 60,
+        width=90,
+        height=90,
+        default_size=18,
+        min_size=10,
+        role="body",
+        ladder=[18, 12],
+    )
+
+    assert font_size == 12
     assert overflowed is False
 
 
@@ -52,7 +84,44 @@ def test_structured_blocks_account_for_heading_hierarchy_and_spacing() -> None:
         ]
     )
 
-    font_size, overflowed = fit_text(content, width=180, height=90, default_size=24)
+    font_size, overflowed = fit_text(content, width=180, height=90, default_size=24, role="body")
 
-    assert font_size < 24
+    assert font_size == 14
     assert overflowed is False
+
+
+def test_precise_measurement_uses_pillow_truetype(monkeypatch) -> None:
+    calls: list[tuple[str, int]] = []
+
+    class FakeFont:
+        def __init__(self, size: int) -> None:
+            self.size = size
+
+        def getlength(self, text: str) -> float:
+            return len(text) * self.size * 0.9
+
+        def getbbox(self, text: str) -> tuple[int, int, int, int]:
+            width = max(int(len(text) * self.size * 0.9), 1)
+            return (0, 0, width, self.size)
+
+    def fake_truetype(font: str, size: int) -> FakeFont:
+        calls.append((font, size))
+        return FakeFont(size)
+
+    monkeypatch.setattr(ImageFont, "truetype", fake_truetype)
+    monkeypatch.setattr(ImageFont, "load_default", lambda: FakeFont(10))
+
+    font_size, overflowed = fit_text(
+        "A" * 18,
+        width=60,
+        height=60,
+        default_size=18,
+        role="body",
+        font_family="DejaVuSans.ttf",
+        ladder=[18, 12],
+        use_precise=True,
+    )
+
+    assert font_size == 12
+    assert overflowed is False
+    assert calls == [("DejaVuSans.ttf", 18), ("DejaVuSans.ttf", 12)]

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -23,6 +23,7 @@ from agent_slides.model.types import (
     NodeContent,
     Slide,
     TextBlock,
+    TextFitting,
 )
 
 
@@ -244,6 +245,12 @@ def test_computed_node_defaults_support_image_nodes() -> None:
 
     assert computed.image_fit == "stretch"
     assert computed.font_size_pt == 0.0
+
+
+def test_text_fitting_supports_custom_ladders() -> None:
+    fitting = TextFitting(default_size=20, min_size=10, ladder=[20, 16, 12])
+
+    assert fitting.ladder == [20, 16, 12]
 
 
 def test_computed_deck_round_trip_applies_only_matching_revision() -> None:


### PR DESCRIPTION
## Summary
- replace the shrink loop in `text_fit.py` with discrete ladders, per-font width factors, and optional Pillow-backed precise measurement
- add `TextFitting.ladder`, design-rule ladder configuration, and deck-level font normalization after reflow
- expand tests for ladder stepping, font factors, normalization, and precise measurement

## Validation
- `UV_CACHE_DIR=/tmp/agent-slides-uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=/tmp/agent-slides-uv-cache uv run pytest -v`

Closes #181