### PR TITLE
Add post-solve layout validation

### DIFF
--- a/src/agent_slides/engine/layout_validator.py
+++ b/src/agent_slides/engine/layout_validator.py
@@ -1,0 +1,224 @@
+"""Post-solve structural validation for layout geometry."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from itertools import combinations
+from typing import Literal, Mapping
+
+from agent_slides.engine.constraints import Rect
+from agent_slides.model.layouts import SLIDE_HEIGHT_PT, SLIDE_WIDTH_PT
+from agent_slides.model.types import ComputedNode, LayoutDef
+
+PEER_TOP_MISMATCH = "PEER_TOP_MISMATCH"
+PEER_WIDTH_MISMATCH = "PEER_WIDTH_MISMATCH"
+GUTTER_MISMATCH = "GUTTER_MISMATCH"
+SAFE_MARGIN_VIOLATION = "SAFE_MARGIN_VIOLATION"
+SLOT_OVERLAP = "SLOT_OVERLAP"
+TEXT_OVERFLOW = "TEXT_OVERFLOW"
+
+
+@dataclass(frozen=True)
+class LayoutViolation:
+    code: str
+    severity: Literal["error", "warning"]
+    message: str
+    slot_refs: tuple[str, ...]
+
+
+def _slot_groups(layout: LayoutDef, attribute: str) -> dict[str, list[str]]:
+    groups: dict[str, list[str]] = defaultdict(list)
+    for slot_name, slot in layout.slots.items():
+        group_name = getattr(slot, attribute)
+        if group_name:
+            groups[str(group_name)].append(slot_name)
+    return groups
+
+
+def _add_violation(
+    violations: list[LayoutViolation],
+    *,
+    code: str,
+    message: str,
+    slot_refs: list[str] | tuple[str, ...],
+    severity: Literal["error", "warning"] = "error",
+) -> None:
+    violations.append(
+        LayoutViolation(
+            code=code,
+            severity=severity,
+            message=message,
+            slot_refs=tuple(dict.fromkeys(slot_refs)),
+        )
+    )
+
+
+def _validate_peer_tops(
+    layout: LayoutDef,
+    rects: Mapping[str, Rect],
+    epsilon: float,
+    violations: list[LayoutViolation],
+) -> None:
+    for group_name, slot_names in _slot_groups(layout, "alignment_group").items():
+        if len(slot_names) < 2:
+            continue
+        ordered = sorted(slot_names, key=lambda slot_name: (rects[slot_name].y, rects[slot_name].x, slot_name))
+        anchor_slot = ordered[0]
+        anchor_top = rects[anchor_slot].y
+        for slot_name in ordered[1:]:
+            top = rects[slot_name].y
+            if abs(top - anchor_top) <= epsilon:
+                continue
+            _add_violation(
+                violations,
+                code=PEER_TOP_MISMATCH,
+                message=(
+                    f"Alignment group '{group_name}' must share a common top edge within {epsilon:g}pt; "
+                    f"'{anchor_slot}' is at {anchor_top:g}pt and '{slot_name}' is at {top:g}pt."
+                ),
+                slot_refs=[anchor_slot, slot_name],
+            )
+
+
+def _validate_peer_widths(
+    layout: LayoutDef,
+    rects: Mapping[str, Rect],
+    epsilon: float,
+    violations: list[LayoutViolation],
+) -> None:
+    for group_name, slot_names in _slot_groups(layout, "peer_group").items():
+        if len(slot_names) < 2:
+            continue
+        ordered = sorted(slot_names, key=lambda slot_name: (rects[slot_name].width, rects[slot_name].x, slot_name))
+        anchor_slot = ordered[0]
+        anchor_width = rects[anchor_slot].width
+        for slot_name in ordered[1:]:
+            width = rects[slot_name].width
+            if abs(width - anchor_width) <= epsilon:
+                continue
+            _add_violation(
+                violations,
+                code=PEER_WIDTH_MISMATCH,
+                message=(
+                    f"Peer group '{group_name}' requires equal widths within {epsilon:g}pt; "
+                    f"'{anchor_slot}' is {anchor_width:g}pt wide and '{slot_name}' is {width:g}pt wide."
+                ),
+                slot_refs=[anchor_slot, slot_name],
+            )
+
+
+def _validate_gutters(
+    layout: LayoutDef,
+    rects: Mapping[str, Rect],
+    epsilon: float,
+    violations: list[LayoutViolation],
+) -> None:
+    for group_name, slot_names in _slot_groups(layout, "peer_group").items():
+        if len(slot_names) < 3:
+            continue
+        ordered = sorted(slot_names, key=lambda slot_name: (rects[slot_name].x, rects[slot_name].y, slot_name))
+        gutters: list[tuple[str, str, float]] = []
+        for left_slot, right_slot in zip(ordered, ordered[1:], strict=False):
+            left_rect = rects[left_slot]
+            right_rect = rects[right_slot]
+            gutters.append((left_slot, right_slot, right_rect.x - (left_rect.x + left_rect.width)))
+        anchor_left, anchor_right, anchor_gutter = gutters[0]
+        for left_slot, right_slot, gutter in gutters[1:]:
+            if abs(gutter - anchor_gutter) <= epsilon:
+                continue
+            _add_violation(
+                violations,
+                code=GUTTER_MISMATCH,
+                message=(
+                    f"Peer group '{group_name}' requires consistent gutters within {epsilon:g}pt; "
+                    f"'{anchor_left}'→'{anchor_right}' is {anchor_gutter:g}pt but "
+                    f"'{left_slot}'→'{right_slot}' is {gutter:g}pt."
+                ),
+                slot_refs=[anchor_left, anchor_right, left_slot, right_slot],
+            )
+
+
+def _validate_bounds(
+    rects: Mapping[str, Rect],
+    *,
+    slide_width: float,
+    slide_height: float,
+    epsilon: float,
+    violations: list[LayoutViolation],
+) -> None:
+    for slot_name, rect in rects.items():
+        right = rect.x + rect.width
+        bottom = rect.y + rect.height
+        if rect.x >= -epsilon and rect.y >= -epsilon and right <= slide_width + epsilon and bottom <= slide_height + epsilon:
+            continue
+        _add_violation(
+            violations,
+            code=SAFE_MARGIN_VIOLATION,
+            message=(
+                f"Slot '{slot_name}' must remain inside the slide bounds; "
+                f"got x={rect.x:g}, y={rect.y:g}, width={rect.width:g}, height={rect.height:g} "
+                f"for a {slide_width:g}x{slide_height:g}pt slide."
+            ),
+            slot_refs=[slot_name],
+        )
+
+
+def _validate_overlap(
+    rects: Mapping[str, Rect],
+    epsilon: float,
+    violations: list[LayoutViolation],
+) -> None:
+    for left_slot, right_slot in combinations(sorted(rects), 2):
+        left_rect = rects[left_slot]
+        right_rect = rects[right_slot]
+        overlap_width = min(left_rect.x + left_rect.width, right_rect.x + right_rect.width) - max(left_rect.x, right_rect.x)
+        overlap_height = min(left_rect.y + left_rect.height, right_rect.y + right_rect.height) - max(left_rect.y, right_rect.y)
+        if overlap_width <= epsilon or overlap_height <= epsilon:
+            continue
+        _add_violation(
+            violations,
+            code=SLOT_OVERLAP,
+            message=(
+                f"Slots '{left_slot}' and '{right_slot}' overlap by "
+                f"{overlap_width:g}x{overlap_height:g}pt."
+            ),
+            slot_refs=[left_slot, right_slot],
+        )
+
+
+def _validate_overflow(
+    computed_by_slot: Mapping[str, ComputedNode],
+    violations: list[LayoutViolation],
+) -> None:
+    for slot_name, computed in computed_by_slot.items():
+        if computed.content_type != "text" or not computed.text_overflow:
+            continue
+        _add_violation(
+            violations,
+            code=TEXT_OVERFLOW,
+            message=f"Slot '{slot_name}' reports explicit text overflow after fitting.",
+            slot_refs=[slot_name],
+        )
+
+
+def validate_layout(
+    layout: LayoutDef,
+    rects: Mapping[str, Rect],
+    epsilon: float = 1.0,
+    *,
+    computed_by_slot: Mapping[str, ComputedNode] | None = None,
+    slide_width: float = SLIDE_WIDTH_PT,
+    slide_height: float = SLIDE_HEIGHT_PT,
+) -> list[LayoutViolation]:
+    """Validate solved slot geometry against layout invariants."""
+
+    violations: list[LayoutViolation] = []
+    _validate_peer_tops(layout, rects, epsilon, violations)
+    _validate_peer_widths(layout, rects, epsilon, violations)
+    _validate_gutters(layout, rects, epsilon, violations)
+    _validate_bounds(rects, slide_width=slide_width, slide_height=slide_height, epsilon=epsilon, violations=violations)
+    _validate_overlap(rects, epsilon, violations)
+    if computed_by_slot is not None:
+        _validate_overflow(computed_by_slot, violations)
+    return violations

--- a/src/agent_slides/engine/reflow.py
+++ b/src/agent_slides/engine/reflow.py
@@ -6,7 +6,8 @@ from collections.abc import Callable
 from math import isclose
 
 from agent_slides.errors import AgentSlidesError, INVALID_SLOT
-from agent_slides.engine.constraints import constraints_from_layout, solve
+from agent_slides.engine.constraints import Rect, constraints_from_layout, solve
+from agent_slides.engine.layout_validator import LayoutViolation, validate_layout
 from agent_slides.engine.slide_revisions import resolve_slide_revision
 from agent_slides.engine.text_fit import fit_text, measure_text_height
 from agent_slides.model import Deck, LayoutDef, Slide
@@ -21,7 +22,10 @@ def _text_fit_rules(layout_def: LayoutDef, node: Node, provider: LayoutProvider 
     slot_name = node.slot_binding or ""
     slot = layout_def.slots[slot_name]
     if provider is not None:
-        return provider.get_text_fitting(layout_def.name, slot.role)
+        try:
+            return provider.get_text_fitting(layout_def.name, slot.role)
+        except AgentSlidesError:
+            pass
     if slot.role in layout_def.text_fitting:
         return layout_def.text_fitting[slot.role]
     if slot.role == "heading":
@@ -50,6 +54,17 @@ def _measure_slot_height_factory(layout_def: LayoutDef, provider: LayoutProvider
         return measure_text_height(node.content, width, fit_rules.default_size)
 
     return measure
+
+
+def _computed_by_slot(slide: Slide) -> dict[str, ComputedNode]:
+    computed_by_slot: dict[str, ComputedNode] = {}
+    for node in slide.nodes:
+        if node.slot_binding is None:
+            continue
+        computed = slide.computed.get(node.node_id)
+        if computed is not None:
+            computed_by_slot[node.slot_binding] = computed
+    return computed_by_slot
 
 
 def _resolve_text_ladder(
@@ -124,7 +139,7 @@ def _reflow_slide(
     revision: int,
     provider: LayoutProvider | None = None,
     design_rules: DesignRules | None = None,
-) -> None:
+) -> dict[str, Rect]:
     computed: dict[str, ComputedNode] = {}
     slide.revision = revision
     active_provider = provider or BuiltinLayoutProvider()
@@ -218,12 +233,14 @@ def _reflow_slide(
         )
 
     slide.computed = computed
+    return rects
 
 
-def reflow_slide(slide: Slide, layout_def: LayoutDef, theme: Theme) -> None:
+def reflow_slide(slide: Slide, layout_def: LayoutDef, theme: Theme) -> list[LayoutViolation]:
     """Compute concrete geometry and styling for a single slide."""
 
-    _reflow_slide(slide, layout_def, theme, revision=0)
+    rects = _reflow_slide(slide, layout_def, theme, revision=0)
+    return validate_layout(layout_def, rects, computed_by_slot=_computed_by_slot(slide))
 
 
 def reflow_deck(
@@ -231,27 +248,40 @@ def reflow_deck(
     provider: LayoutProvider | None = None,
     *,
     previous_slide_signatures: dict[str, object] | None = None,
-) -> None:
+) -> dict[str, list[LayoutViolation]]:
     """Reflow every slide in the deck using the deck theme."""
 
     active_provider = provider or BuiltinLayoutProvider()
     theme = _resolve_theme(deck, active_provider)
     design_rules = load_design_rules(deck.design_rules)
+    rects_by_slide: dict[str, dict[str, Rect]] = {}
     for slide in deck.slides:
+        layout_def = active_provider.get_layout(slide.layout)
         slide_revision = resolve_slide_revision(
             slide,
             deck_revision=deck.revision,
             previous_slide_signatures=previous_slide_signatures,
         )
-        _reflow_slide(
+        rects_by_slide[slide.slide_id] = _reflow_slide(
             slide,
-            active_provider.get_layout(slide.layout),
+            layout_def,
             theme,
             revision=slide_revision,
             provider=active_provider,
             design_rules=design_rules,
         )
     _normalize_deck_font_sizes(deck, active_provider, design_rules)
+    violations_by_slide: dict[str, list[LayoutViolation]] = {}
+    for slide in deck.slides:
+        layout_def = active_provider.get_layout(slide.layout)
+        violations = validate_layout(
+            layout_def,
+            rects_by_slide[slide.slide_id],
+            computed_by_slot=_computed_by_slot(slide),
+        )
+        if violations:
+            violations_by_slide[slide.slide_id] = violations
+    return violations_by_slide
 
 
 def rebind_slots(

--- a/src/agent_slides/model/template_layouts.py
+++ b/src/agent_slides/model/template_layouts.py
@@ -470,7 +470,10 @@ def _copy_slot(slot: SlotDef, **updates: Any) -> SlotDef:
     return slot.model_copy(update=updates)
 
 
-def _is_valid_variant(*, heading: SlotDef, bodies: list[SlotDef]) -> bool:
+def _is_valid_variant(*, heading: SlotDef, bodies: list[SlotDef], theme: Theme) -> bool:
+    from agent_slides.engine.constraints import constraints_from_layout, solve
+    from agent_slides.engine.layout_validator import validate_layout
+
     if heading.x is None or heading.y is None or heading.width is None or heading.height is None:
         return False
     if not bodies:
@@ -484,10 +487,21 @@ def _is_valid_variant(*, heading: SlotDef, bodies: list[SlotDef]) -> bool:
         first_alignment = bodies[0].alignment_group
         if first_alignment is None or any(slot.alignment_group != first_alignment for slot in bodies[1:]):
             return False
-    return True
+    validation_slots = {
+        "heading": heading,
+        **{f"body_{index}": body for index, body in enumerate(bodies, start=1)},
+    }
+    validation_layout = LayoutDef(
+        name="variant_validation",
+        slots=validation_slots,
+        grid=_TEMPLATE_GRID,
+        text_fitting=_variant_text_fitting(validation_slots),
+    )
+    rects = solve(constraints_from_layout(validation_layout, theme), {}, lambda _slot_name, _content, _width: 0.0)
+    return not any(violation.severity == "error" for violation in validate_layout(validation_layout, rects))
 
 
-def _generate_variants(layout: LayoutDef) -> list[LayoutDef]:
+def _generate_variants(layout: LayoutDef, theme: Theme) -> list[LayoutDef]:
     heading_slots = [slot for _, slot in _reading_order(layout.slots) if slot.role == "heading"]
     body_slots = [slot for _, slot in _reading_order(layout.slots) if slot.role == "body"]
     if len(heading_slots) != 1 or len(body_slots) < 1:
@@ -496,7 +510,7 @@ def _generate_variants(layout: LayoutDef) -> list[LayoutDef]:
     heading = heading_slots[0]
     variants: list[LayoutDef] = []
 
-    if len(body_slots) == 2 and _is_valid_variant(heading=heading, bodies=[body_slots[0]]):
+    if len(body_slots) == 2 and _is_valid_variant(heading=heading, bodies=[body_slots[0]], theme=theme):
         title_content_slots = {
             "heading": _copy_slot(heading, peer_group=None, alignment_group="top", reading_order=0, size_policy="fit_content"),
             "body": _copy_slot(
@@ -516,7 +530,7 @@ def _generate_variants(layout: LayoutDef) -> list[LayoutDef]:
             )
         )
 
-    if len(body_slots) >= 2 and _is_valid_variant(heading=heading, bodies=body_slots[:2]):
+    if len(body_slots) >= 2 and _is_valid_variant(heading=heading, bodies=body_slots[:2], theme=theme):
         two_col_slots = {
             "heading": _copy_slot(heading, peer_group=None, alignment_group="top", reading_order=0, size_policy="fit_content"),
             "col1": _copy_slot(
@@ -543,7 +557,7 @@ def _generate_variants(layout: LayoutDef) -> list[LayoutDef]:
             )
         )
 
-    if len(body_slots) >= 3 and _is_valid_variant(heading=heading, bodies=body_slots[:3]):
+    if len(body_slots) >= 3 and _is_valid_variant(heading=heading, bodies=body_slots[:3], theme=theme):
         three_col_slots = {
             "heading": _copy_slot(heading, peer_group=None, alignment_group="top", reading_order=0, size_policy="fit_content"),
             "col1": _copy_slot(
@@ -645,7 +659,7 @@ class TemplateLayoutRegistry:
             )
             self._slot_names[slug] = list(slot_mapping)
             self._layout_refs[slug] = (master_index, layout_index)
-            self._variants[slug] = _generate_variants(self._layouts[slug])
+            self._variants[slug] = _generate_variants(self._layouts[slug], self._theme)
             if bool(raw_layout.get("usable", raw_layout.get("is_usable", True))):
                 self._usable_layouts.append(slug)
 

--- a/tests/test_layout_validator.py
+++ b/tests/test_layout_validator.py
@@ -1,0 +1,274 @@
+from __future__ import annotations
+
+from agent_slides.engine.constraints import Rect
+from agent_slides.engine.layout_validator import (
+    GUTTER_MISMATCH,
+    PEER_TOP_MISMATCH,
+    PEER_WIDTH_MISMATCH,
+    SAFE_MARGIN_VIOLATION,
+    SLOT_OVERLAP,
+    TEXT_OVERFLOW,
+    validate_layout,
+)
+from agent_slides.engine.reflow import reflow_deck, reflow_slide
+from agent_slides.model import ComputedNode, Counters, Deck, GridDef, LayoutDef, Node, Slide, SlotDef, TextFitting
+from agent_slides.model.themes import load_theme
+
+
+def _layout(slots: dict[str, SlotDef]) -> LayoutDef:
+    return LayoutDef(
+        name="custom",
+        slots=slots,
+        grid=GridDef(columns=1, rows=1, row_heights=[1.0], col_widths=[1.0], margin=0.0, gutter=0.0),
+        text_fitting={
+            "heading": TextFitting(default_size=32.0, min_size=24.0),
+            "body": TextFitting(default_size=18.0, min_size=10.0),
+        },
+    )
+
+
+def _body_slot(*, x: float, y: float, width: float, height: float, peer_group: str = "columns") -> SlotDef:
+    return SlotDef(
+        grid_row=1,
+        grid_col=1,
+        role="body",
+        peer_group=peer_group,
+        alignment_group="content",
+        x=x,
+        y=y,
+        width=width,
+        height=height,
+    )
+
+
+def test_validate_layout_checks_peer_top_alignment_with_epsilon() -> None:
+    layout = _layout(
+        {
+            "col1": _body_slot(x=60.0, y=120.0, width=180.0, height=220.0),
+            "col2": _body_slot(x=260.0, y=121.5, width=180.0, height=220.0),
+        }
+    )
+
+    within_epsilon = validate_layout(
+        layout,
+        {
+            "col1": Rect(x=60.0, y=120.0, width=180.0, height=220.0),
+            "col2": Rect(x=260.0, y=120.5, width=180.0, height=220.0),
+        },
+        epsilon=1.0,
+    )
+    beyond_epsilon = validate_layout(
+        layout,
+        {
+            "col1": Rect(x=60.0, y=120.0, width=180.0, height=220.0),
+            "col2": Rect(x=260.0, y=122.5, width=180.0, height=220.0),
+        },
+        epsilon=1.0,
+    )
+
+    assert within_epsilon == []
+    assert [violation.code for violation in beyond_epsilon] == [PEER_TOP_MISMATCH]
+    assert beyond_epsilon[0].slot_refs == ("col1", "col2")
+
+
+def test_validate_layout_checks_peer_widths() -> None:
+    layout = _layout(
+        {
+            "col1": _body_slot(x=60.0, y=120.0, width=180.0, height=220.0),
+            "col2": _body_slot(x=260.0, y=120.0, width=188.0, height=220.0),
+        }
+    )
+
+    violations = validate_layout(
+        layout,
+        {
+            "col1": Rect(x=60.0, y=120.0, width=180.0, height=220.0),
+            "col2": Rect(x=260.0, y=120.0, width=188.0, height=220.0),
+        },
+    )
+
+    assert [violation.code for violation in violations] == [PEER_WIDTH_MISMATCH]
+    assert violations[0].slot_refs == ("col1", "col2")
+
+
+def test_validate_layout_checks_consistent_gutters() -> None:
+    layout = _layout(
+        {
+            "col1": _body_slot(x=60.0, y=120.0, width=160.0, height=220.0),
+            "col2": _body_slot(x=240.0, y=120.0, width=160.0, height=220.0),
+            "col3": _body_slot(x=432.0, y=120.0, width=160.0, height=220.0),
+        }
+    )
+
+    violations = validate_layout(
+        layout,
+        {
+            "col1": Rect(x=60.0, y=120.0, width=160.0, height=220.0),
+            "col2": Rect(x=240.0, y=120.0, width=160.0, height=220.0),
+            "col3": Rect(x=432.0, y=120.0, width=160.0, height=220.0),
+        },
+    )
+
+    assert [violation.code for violation in violations] == [GUTTER_MISMATCH]
+    assert violations[0].slot_refs == ("col1", "col2", "col3")
+
+
+def test_validate_layout_checks_bounds_and_overlap_edges() -> None:
+    layout = _layout(
+        {
+            "left": _body_slot(x=-8.0, y=40.0, width=180.0, height=220.0, peer_group="cards"),
+            "center": _body_slot(x=172.0, y=40.0, width=180.0, height=220.0, peer_group="cards"),
+            "right": _body_slot(x=340.0, y=40.0, width=180.0, height=220.0, peer_group="cards"),
+        }
+    )
+
+    violations = validate_layout(
+        layout,
+        {
+            "left": Rect(x=-8.0, y=40.0, width=180.0, height=220.0),
+            "center": Rect(x=172.0, y=40.0, width=180.0, height=220.0),
+            "right": Rect(x=352.0, y=40.0, width=180.0, height=220.0),
+        },
+    )
+
+    assert [violation.code for violation in violations] == [SAFE_MARGIN_VIOLATION]
+
+    touching_only = validate_layout(
+        layout,
+        {
+            "left": Rect(x=20.0, y=40.0, width=160.0, height=220.0),
+            "center": Rect(x=180.0, y=40.0, width=160.0, height=220.0),
+            "right": Rect(x=340.0, y=40.0, width=180.0, height=220.0),
+        },
+    )
+    assert all(violation.code != SLOT_OVERLAP for violation in touching_only)
+
+    overlapping = validate_layout(
+        layout,
+        {
+            "left": Rect(x=20.0, y=40.0, width=180.0, height=220.0),
+            "center": Rect(x=180.0, y=40.0, width=180.0, height=220.0),
+            "right": Rect(x=380.0, y=40.0, width=180.0, height=220.0),
+        },
+    )
+    assert SLOT_OVERLAP in [violation.code for violation in overlapping]
+
+
+def test_validate_layout_reports_explicit_text_overflow() -> None:
+    layout = _layout({"body": _body_slot(x=60.0, y=120.0, width=420.0, height=120.0, peer_group="body")})
+
+    violations = validate_layout(
+        layout,
+        {"body": Rect(x=60.0, y=120.0, width=420.0, height=120.0)},
+        computed_by_slot={
+            "body": ComputedNode(
+                x=60.0,
+                y=120.0,
+                width=420.0,
+                height=120.0,
+                font_size_pt=10.0,
+                font_family="Calibri",
+                color="#000000",
+                revision=0,
+                text_overflow=True,
+                content_type="text",
+            )
+        },
+    )
+
+    assert [violation.code for violation in violations] == [TEXT_OVERFLOW]
+    assert violations[0].slot_refs == ("body",)
+
+
+def test_reflow_slide_returns_layout_validator_errors() -> None:
+    layout = _layout(
+        {
+            "left": SlotDef(
+                grid_row=1,
+                grid_col=1,
+                role="body",
+                peer_group="columns",
+                alignment_group="content",
+                x=60.0,
+                y=140.0,
+                width=180.0,
+                height=220.0,
+            ),
+            "right": SlotDef(
+                grid_row=1,
+                grid_col=1,
+                role="body",
+                peer_group="columns",
+                alignment_group="content",
+                x=270.0,
+                y=154.0,
+                width=196.0,
+                height=220.0,
+            ),
+        }
+    )
+    slide = Slide(
+        slide_id="s-1",
+        layout="custom",
+        nodes=[
+            Node(node_id="n-1", slot_binding="left", type="text", content="Left column"),
+            Node(node_id="n-2", slot_binding="right", type="text", content="Right column"),
+        ],
+    )
+
+    violations = reflow_slide(slide, layout, load_theme("default"))
+
+    assert {violation.code for violation in violations} == {PEER_TOP_MISMATCH, PEER_WIDTH_MISMATCH}
+
+
+class _SingleLayoutProvider:
+    def __init__(self, layout: LayoutDef) -> None:
+        self._layout = layout
+
+    def get_layout(self, slug: str) -> LayoutDef:
+        assert slug == self._layout.name
+        return self._layout
+
+    def list_layouts(self) -> list[str]:
+        return [self._layout.name]
+
+    def get_slot_names(self, slug: str) -> list[str]:
+        return list(self.get_layout(slug).slots)
+
+    def get_text_fitting(self, slug: str, role: str) -> TextFitting:
+        return self.get_layout(slug).text_fitting[role]
+
+    def get_variants(self, slug: str) -> list[LayoutDef]:
+        self.get_layout(slug)
+        return []
+
+
+def test_reflow_deck_returns_validator_errors_by_slide() -> None:
+    layout = _layout(
+        {
+            "left": _body_slot(x=60.0, y=120.0, width=180.0, height=220.0),
+            "right": _body_slot(x=260.0, y=134.0, width=196.0, height=220.0),
+        }
+    ).model_copy(update={"name": "custom"})
+    deck = Deck(
+        deck_id="deck-invalid",
+        slides=[
+            Slide(
+                slide_id="s-1",
+                layout="custom",
+                nodes=[
+                    Node(node_id="n-1", slot_binding="left", type="text", content="Left"),
+                    Node(node_id="n-2", slot_binding="right", type="text", content="Right"),
+                ],
+            )
+        ],
+        counters=Counters(slides=1, nodes=2),
+    )
+
+    violations_by_slide = reflow_deck(deck, provider=_SingleLayoutProvider(layout))
+
+    assert set(violations_by_slide) == {"s-1"}
+    assert {violation.code for violation in violations_by_slide["s-1"]} == {
+        PEER_TOP_MISMATCH,
+        PEER_WIDTH_MISMATCH,
+    }

--- a/tests/test_template_layouts.py
+++ b/tests/test_template_layouts.py
@@ -286,6 +286,20 @@ def test_template_layout_registry_skips_variants_when_peer_invariants_fail(tmp_p
     assert registry.get_variants("peer_bodies") == []
 
 
+def test_template_layout_registry_skips_variants_when_solved_widths_differ(tmp_path: Path) -> None:
+    manifest_path = _build_variant_manifest(
+        tmp_path,
+        body_bounds=[
+            {"x": 72, "y": 156, "w": 180, "h": 220},
+            {"x": 270, "y": 156, "w": 210, "h": 220},
+            {"x": 508, "y": 156, "w": 140, "h": 220},
+        ],
+    )
+    registry = TemplateLayoutRegistry(str(manifest_path))
+
+    assert registry.get_variants("peer_bodies") == []
+
+
 def test_layout_providers_expose_get_variants_consistently(tmp_path: Path) -> None:
     manifest_path = _build_variant_manifest(
         tmp_path,


### PR DESCRIPTION
## Summary
- add a post-solve layout validator for peer alignment, peer widths, gutters, slide bounds, overlap, and explicit overflow
- return layout violations from `reflow_slide()` and `reflow_deck()` while keeping existing mutation/build flows intact
- gate template semantic variants with solved-geometry validation and add targeted invariant coverage

Closes #184

## Testing
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`