### PR TITLE
Auto-detect bullet lines in --text input

### DIFF
--- a/src/agent_slides/model/types.py
+++ b/src/agent_slides/model/types.py
@@ -280,7 +280,9 @@ class NodeContent(AgentSlidesModel):
     def from_text(cls, text: str, *, block_type: Literal["paragraph", "bullet", "heading"] = "paragraph") -> NodeContent:
         if text == "":
             return cls()
-        return cls(blocks=[TextBlock(type=block_type, text=text)])
+        if block_type != "paragraph":
+            return cls(blocks=[TextBlock(type=block_type, text=text)])
+        return cls(blocks=parse_text_blocks(text))
 
     def to_plain_text(self) -> str:
         return "\n".join(block.text for block in self.blocks)
@@ -401,6 +403,31 @@ def split_text_runs_by_line(block: TextBlock) -> list[list[TextRun]]:
             if has_line_break:
                 line_runs.append([])
     return line_runs or [[TextRun(text="")]]
+
+
+def parse_text_blocks(text: str) -> list[TextBlock]:
+    if "\n" not in text:
+        return [TextBlock(type="paragraph", text=text)]
+
+    lines = text.splitlines()
+    if not any(_is_bullet_line(line) for line in lines):
+        return [TextBlock(type="paragraph", text=text)]
+
+    blocks: list[TextBlock] = []
+    for line in lines:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if _is_bullet_line(stripped):
+            blocks.append(TextBlock(type="bullet", text=stripped[2:]))
+            continue
+        blocks.append(TextBlock(type="paragraph", text=stripped))
+    return blocks
+
+
+def _is_bullet_line(text: str) -> bool:
+    stripped = text.strip()
+    return stripped.startswith("- ") or stripped.startswith("* ")
 
 
 def _merge_adjacent_runs(runs: list[TextRun]) -> list[TextRun]:

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -849,6 +849,42 @@ def test_slot_set_parses_inline_markdown_runs_from_text(tmp_path: Path) -> None:
     ]
 
 
+def test_slot_set_auto_detects_bullet_lines_from_text(tmp_path: Path) -> None:
+    deck_path = tmp_path / "deck.json"
+    deck = Deck(
+        deck_id="deck-1",
+        slides=[build_slide("s-1", "title_content", ["heading", "body"], start_node=1)],
+        counters=Counters(slides=1, nodes=3),
+    )
+    write_deck(deck_path, deck)
+
+    result = invoke_cli(
+        [
+            "slot",
+            "set",
+            str(deck_path),
+            "--slide",
+            "s-1",
+            "--slot",
+            "body",
+            "--text",
+            "Key points:\n- First item\n* Second item",
+        ]
+    )
+    payload = json.loads(result.stdout)
+    updated = read_deck(str(deck_path))
+
+    assert result.exit_code == 0
+    assert payload["data"]["content"] == {
+        "blocks": [
+            {"type": "paragraph", "text": "Key points:", "level": 0},
+            {"type": "bullet", "text": "First item", "level": 0},
+            {"type": "bullet", "text": "Second item", "level": 0},
+        ]
+    }
+    assert updated.slides[0].nodes[1].content.to_plain_text() == "Key points:\nFirst item\nSecond item"
+
+
 def test_slot_set_parses_inline_markdown_color_suffixes(tmp_path: Path) -> None:
     deck_path = tmp_path / "deck.json"
     deck = Deck(

--- a/tests/test_e2e.py
+++ b/tests/test_e2e.py
@@ -2,12 +2,19 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from xml.etree import ElementTree as ET
+from zipfile import ZipFile
 
 from click.testing import CliRunner
 from pptx import Presentation
 
 from agent_slides.cli import cli
 from agent_slides.errors import UNBOUND_NODES
+
+DRAWING_NS = {
+    "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
+    "p": "http://schemas.openxmlformats.org/presentationml/2006/main",
+}
 
 
 def collect_slide_text(path: Path) -> list[str]:
@@ -18,6 +25,11 @@ def collect_slide_text(path: Path) -> list[str]:
             if shape.has_text_frame:
                 text_values.append(shape.text_frame.text)
     return text_values
+
+
+def read_slide_xml(path: Path, *, index: int = 1) -> ET.Element:
+    with ZipFile(path) as archive:
+        return ET.fromstring(archive.read(f"ppt/slides/slide{index}.xml"))
 
 
 def invoke(runner: CliRunner, args: list[str], *, input_text: str | None = None) -> tuple[int, dict[str, object], str]:
@@ -83,6 +95,63 @@ def test_full_demo_flow(tmp_path: Path) -> None:
     assert "Second point" in all_text
     assert "The best way to predict the future is to invent it." in all_text
     assert "Alan Kay" in all_text
+
+
+def test_build_renders_auto_detected_text_bullets_as_native_pptx_bullets(tmp_path: Path) -> None:
+    runner = CliRunner()
+    deck_path = tmp_path / "deck.json"
+    pptx_path = tmp_path / "output.pptx"
+
+    exit_code, payload, _ = invoke(runner, ["init", str(deck_path), "--theme", "default"])
+    assert exit_code == 0
+    assert payload["ok"] is True
+
+    exit_code, payload, _ = invoke(runner, ["slide", "add", str(deck_path), "--layout", "title_content"])
+    assert exit_code == 0
+    assert payload["ok"] is True
+
+    exit_code, payload, _ = invoke(
+        runner,
+        [
+            "slot",
+            "set",
+            str(deck_path),
+            "--slide",
+            "0",
+            "--slot",
+            "body",
+            "--text",
+            "Key points:\n- First item\n* Second item",
+        ],
+    )
+    assert exit_code == 0
+    assert payload["ok"] is True
+
+    exit_code, payload, _ = invoke(runner, ["build", str(deck_path), "-o", str(pptx_path)])
+    assert exit_code == 0
+    assert payload["ok"] is True
+
+    presentation = Presentation(str(pptx_path))
+    text_frame = next(
+        shape.text_frame
+        for shape in presentation.slides[0].shapes
+        if shape.has_text_frame and shape.text_frame.text == "Key points:\nFirst item\nSecond item"
+    )
+    body_shape = next(
+        shape
+        for shape in read_slide_xml(pptx_path).findall(".//p:sp", DRAWING_NS)
+        if [text.text for text in shape.findall(".//a:t", DRAWING_NS)] == ["Key points:", "First item", "Second item"]
+    )
+    paragraphs = body_shape.findall(".//a:p", DRAWING_NS)
+
+    assert [paragraph.text for paragraph in text_frame.paragraphs] == [
+        "Key points:",
+        "First item",
+        "Second item",
+    ]
+    assert paragraphs[0].find("./a:pPr/a:buChar", DRAWING_NS) is None
+    assert paragraphs[1].find("./a:pPr/a:buChar", DRAWING_NS) is not None
+    assert paragraphs[2].find("./a:pPr/a:buChar", DRAWING_NS) is not None
 
 
 def test_layout_switch_content_migration(tmp_path: Path) -> None:

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -143,6 +143,28 @@ def test_legacy_string_content_is_coerced_to_structured_paragraphs() -> None:
     assert node.content == NodeContent(blocks=[TextBlock(type="paragraph", text="Hello world")])
 
 
+def test_node_content_from_text_converts_mixed_bullet_lines_to_blocks() -> None:
+    content = NodeContent.from_text("Key points:\n- First item\n* Second item")
+
+    assert content == NodeContent(
+        blocks=[
+            TextBlock(type="paragraph", text="Key points:"),
+            TextBlock(type="bullet", text="First item"),
+            TextBlock(type="bullet", text="Second item"),
+        ]
+    )
+
+
+def test_node_content_from_text_keeps_empty_single_line_and_plain_multiline_text_unchanged() -> None:
+    assert NodeContent.from_text("") == NodeContent(blocks=[])
+    assert NodeContent.from_text("Hello world") == NodeContent(
+        blocks=[TextBlock(type="paragraph", text="Hello world")]
+    )
+    assert NodeContent.from_text("Line one\nLine two") == NodeContent(
+        blocks=[TextBlock(type="paragraph", text="Line one\nLine two")]
+    )
+
+
 def test_next_ids_increment_counters() -> None:
     deck = Deck(deck_id="deck-1")
 


### PR DESCRIPTION
## Summary
- auto-detect `- ` and `* ` lines in `NodeContent.from_text()` when plain `--text` input contains bullets
- preserve existing single-line and non-bullet multiline paragraph behavior
- add model, CLI, and PPTX-level regression coverage for native PowerPoint bullets

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run python - <<'PY' ...` direct CLI proof for `slot set --text` and PPTX bullet XML
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q tests/test_types.py tests/test_commands.py tests/test_e2e.py`
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`

Closes #207