### PR TITLE
Fix preview foreground readiness timing

### DIFF
--- a/src/agent_slides/commands/preview.py
+++ b/src/agent_slides/commands/preview.py
@@ -114,15 +114,16 @@ class _ForegroundPreviewServer:
         *,
         port: int,
     ) -> None:
-        self._server = PreviewServer(
-            str(path),
-            port=port,
-        )
         self._thread: threading.Thread | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._stop_event: asyncio.Event | None = None
         self._ready = threading.Event()
         self._startup_error: Exception | None = None
+        self._server = PreviewServer(
+            str(path),
+            port=port,
+            on_listening=self._ready.set,
+        )
 
     @property
     def url(self) -> str:
@@ -152,7 +153,6 @@ class _ForegroundPreviewServer:
         async def serve() -> None:
             try:
                 await self._server.start()
-                self._ready.set()
                 await self._stop_event.wait()
             except Exception as exc:  # pragma: no cover - surfaced through start()
                 self._startup_error = exc

--- a/src/agent_slides/preview/server.py
+++ b/src/agent_slides/preview/server.py
@@ -12,7 +12,7 @@ import threading
 from http import HTTPStatus
 from importlib import resources
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 from urllib.parse import unquote
 
 from websockets.datastructures import Headers
@@ -44,6 +44,7 @@ class PreviewServer:
         debounce_ms: int | None = None,
         debounce_interval: float | None = None,
         logger: logging.Logger | None = None,
+        on_listening: Callable[[], None] | None = None,
     ) -> None:
         self.sidecar_path = Path(sidecar_path).resolve()
         self.host = host
@@ -71,6 +72,7 @@ class PreviewServer:
             self._renderer = SlideRenderer(self.sidecar_path)
         self._logged_png_fallback_warning = False
         self._logged_png_cache_fallback_warning = False
+        self._on_listening = on_listening
 
     @property
     def origin(self) -> str:
@@ -104,6 +106,8 @@ class PreviewServer:
         socket = next(iter(self._server.sockets or []), None)
         if socket is not None:
             self.port = int(socket.getsockname()[1])
+        if self._on_listening is not None:
+            self._on_listening()
 
         await self._watcher.start()
         await self._prime_preview_state()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import json
 import os
@@ -9,6 +10,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from uuid import UUID
 
@@ -2778,6 +2780,64 @@ def test_preview_command_starts_server_opens_browser_and_stops_cleanly(
         },
     }
     assert json.loads(lines[1]) == {"ok": True, "data": {"stopped": True}}
+
+
+def test_foreground_preview_server_marks_ready_when_socket_is_bound(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    from agent_slides.commands.preview import _ForegroundPreviewServer
+
+    class _ReadyHandler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # noqa: N802
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"ok": true}')
+
+        def log_message(self, format: str, *args: object) -> None:
+            return
+
+    class SlowStartupPreviewServer:
+        def __init__(self, path: str, *, port: int, on_listening=None) -> None:
+            del path
+            self.host = "127.0.0.1"
+            self.port = port
+            self.origin = f"http://{self.host}:{self.port}"
+            self._on_listening = on_listening
+            self._httpd: HTTPServer | None = None
+            self._thread: threading.Thread | None = None
+
+        async def start(self) -> SlowStartupPreviewServer:
+            self._httpd = HTTPServer((self.host, self.port), _ReadyHandler)
+            self.port = int(self._httpd.server_address[1])
+            self.origin = f"http://{self.host}:{self.port}"
+            self._thread = threading.Thread(target=self._httpd.serve_forever, daemon=True)
+            self._thread.start()
+            if self._on_listening is not None:
+                self._on_listening()
+            await asyncio.sleep(5.2)
+            return self
+
+        async def stop(self) -> None:
+            if self._httpd is not None:
+                self._httpd.shutdown()
+                self._httpd.server_close()
+            if self._thread is not None:
+                self._thread.join(timeout=1)
+
+    deck_path = tmp_path / "deck.json"
+    write_deck(deck_path, make_clean_deck())
+    monkeypatch.setattr("agent_slides.commands.preview.PreviewServer", SlowStartupPreviewServer)
+
+    server = _ForegroundPreviewServer(deck_path, port=0)
+    try:
+        server.start()
+        status, body = wait_for_http(server.url)
+        assert status == 200
+        assert json.loads(body) == {"ok": True}
+    finally:
+        server.stop()
 
 
 def test_preview_command_supports_custom_port_and_no_open(


### PR DESCRIPTION
## Summary
- signal foreground preview readiness as soon as the HTTP socket is bound
- keep `PreviewServer.start()` behavior intact while exposing a lightweight `on_listening` hook
- add a regression test covering slow post-bind startup work in foreground preview mode

## Validation
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest -q tests/test_commands.py -k "foreground_preview_server_marks_ready_when_socket_is_bound or preview_command_starts_server_opens_browser_and_stops_cleanly"`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=$PWD/.uv-cache uv run pytest -q`

Closes #209