### PR TITLE
Fix preview watcher to track computed sidecar updates

### DIFF
--- a/src/agent_slides/preview/server.py
+++ b/src/agent_slides/preview/server.py
@@ -20,6 +20,7 @@ from websockets.http11 import Response
 from websockets.asyncio.server import Server, ServerConnection, broadcast, serve
 
 from agent_slides.errors import AgentSlidesError, FILE_NOT_FOUND
+from agent_slides.io import computed_sidecar_path
 from agent_slides.io.assets import resolve_image_path
 from agent_slides.preview.renderer import SlideRenderError, SlideRenderer
 from agent_slides.preview.watcher import SidecarWatcher, load_deck_payload
@@ -57,6 +58,7 @@ class PreviewServer:
         self._watcher = SidecarWatcher(
             self.sidecar_path,
             self._broadcast_update,
+            watched_path=computed_sidecar_path(self.sidecar_path),
             debounce_ms=effective_debounce_ms,
             logger=self._logger,
         )
@@ -313,10 +315,14 @@ class PreviewServer:
     def _slide_revision(self, slide_payload: dict[str, Any], deck_revision: int) -> int:
         return int(slide_payload.get("revision", deck_revision))
 
-    def _slide_signature(self, payload: dict[str, Any]) -> list[tuple[str, int]]:
+    def _slide_signature(self, payload: dict[str, Any]) -> list[tuple[str, int, str]]:
         deck_revision = int(payload["revision"])
         return [
-            (str(slide["slide_id"]), self._slide_revision(slide, deck_revision))
+            (
+                str(slide["slide_id"]),
+                self._slide_revision(slide, deck_revision),
+                json.dumps(slide, sort_keys=True, separators=(",", ":")),
+            )
             for slide in payload.get("slides", [])
         ]
 
@@ -333,14 +339,17 @@ class PreviewServer:
         current_signature = self._slide_signature(payload)
         if len(previous_signature) != len(current_signature):
             return list(range(len(slides)))
-        if any(previous_id != current_id for (previous_id, _), (current_id, _) in zip(previous_signature, current_signature)):
+        if any(
+            previous_id != current_id
+            for (previous_id, _, _), (current_id, _, _) in zip(previous_signature, current_signature)
+        ):
             return list(range(len(slides)))
         return [
             index
-            for index, ((_, previous_revision), (_, current_revision)) in enumerate(
+            for index, ((_, previous_revision, previous_slide), (_, current_revision, current_slide)) in enumerate(
                 zip(previous_signature, current_signature)
             )
-            if previous_revision != current_revision
+            if previous_revision != current_revision or previous_slide != current_slide
         ]
 
     def _build_slide_previews(self, payload: dict[str, Any]) -> list[dict[str, Any]]:

--- a/src/agent_slides/preview/watcher.py
+++ b/src/agent_slides/preview/watcher.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import json
 import logging
 import sys
 from copy import deepcopy
@@ -51,6 +53,11 @@ def load_deck_payload(sidecar_path: Path) -> tuple[int, DeckPayload]:
     return deck.revision, _enrich_icon_payload(payload)
 
 
+def _payload_digest(payload: DeckPayload) -> str:
+    serialized = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha1(serialized).hexdigest()
+
+
 class _SidecarEventHandler(FileSystemEventHandler):
     def __init__(self, watcher: SidecarWatcher) -> None:
         self._watcher = watcher
@@ -64,32 +71,36 @@ class _SidecarEventHandler(FileSystemEventHandler):
 
 
 class SidecarWatcher:
-    """Watch a deck sidecar file and publish updates on revision changes."""
+    """Watch a sidecar file path and publish updates when the deck payload changes."""
 
     def __init__(
         self,
         sidecar_path: str | Path,
         on_revision_change: UpdateCallback,
         *,
+        watched_path: str | Path | None = None,
         debounce_ms: int = 50,
         logger: logging.Logger | None = None,
     ) -> None:
         self.sidecar_path = Path(sidecar_path).resolve()
+        self.watched_path = (
+            Path(watched_path).resolve() if watched_path is not None else self.sidecar_path
+        )
         self._on_revision_change = on_revision_change
-        self._debounce_seconds = debounce_ms / 1000
+        self._debounce_seconds = max(debounce_ms, 0) / 1000
         self._logger = logger or logging.getLogger(__name__)
         self._observer: Observer | PollingObserver | None = None
         self._loop: asyncio.AbstractEventLoop | None = None
         self._pending_check: asyncio.TimerHandle | None = None
-        self._last_seen_revision: int | None = None
+        self._last_seen_payload_digest: str | None = None
 
     async def start(self) -> None:
         self._loop = asyncio.get_running_loop()
-        self._last_seen_revision = self._read_last_seen_revision()
+        self._last_seen_payload_digest = self._read_last_seen_payload_digest()
         self._observer = self._build_observer()
         self._observer.schedule(
             _SidecarEventHandler(self),
-            str(self.sidecar_path.parent),
+            str(self.watched_path.parent),
             recursive=False,
         )
         self._observer.start()
@@ -108,7 +119,7 @@ class SidecarWatcher:
 
     def matches_event(self, event: FileSystemEvent) -> bool:
         paths = [getattr(event, "src_path", None), getattr(event, "dest_path", None)]
-        target = str(self.sidecar_path)
+        target = str(self.watched_path)
 
         return any(path and str(Path(path).resolve()) == target for path in paths)
 
@@ -120,28 +131,29 @@ class SidecarWatcher:
 
     async def check_for_update(self) -> bool:
         try:
-            revision, payload = load_deck_payload(self.sidecar_path)
+            _, payload = load_deck_payload(self.sidecar_path)
         except AgentSlidesError as exc:
             if exc.code != FILE_NOT_FOUND:
                 self._logger.warning("Preview watcher skipped update: %s", exc.message)
             return False
 
-        if revision == self._last_seen_revision:
+        payload_digest = _payload_digest(payload)
+        if payload_digest == self._last_seen_payload_digest:
             return False
 
-        self._last_seen_revision = revision
+        self._last_seen_payload_digest = payload_digest
         await self._on_revision_change(payload)
         return True
 
-    def _read_last_seen_revision(self) -> int | None:
+    def _read_last_seen_payload_digest(self) -> str | None:
         try:
-            revision, _ = load_deck_payload(self.sidecar_path)
+            _, payload = load_deck_payload(self.sidecar_path)
         except AgentSlidesError as exc:
             if exc.code != FILE_NOT_FOUND:
                 self._logger.warning("Preview watcher could not read initial deck: %s", exc.message)
             return None
 
-        return revision
+        return _payload_digest(payload)
 
     def _schedule_debounced_check(self) -> None:
         if self._pending_check is not None:

--- a/tests/test_preview.py
+++ b/tests/test_preview.py
@@ -11,8 +11,9 @@ from urllib.parse import quote
 import pytest
 from websockets.asyncio.client import connect
 from websockets.exceptions import InvalidStatus
+from watchdog.events import FileModifiedEvent
 
-from agent_slides.io import read_deck
+from agent_slides.io import computed_sidecar_path, read_deck, write_computed_deck
 from agent_slides.model import (
     ChartSpec,
     ComputedNode,
@@ -488,6 +489,61 @@ def test_sidecar_watcher_detects_revision_change_and_debounces(tmp_path: Path) -
     asyncio.run(scenario())
 
 
+def test_sidecar_watcher_supports_watching_computed_sidecar(tmp_path: Path) -> None:
+    deck_path = tmp_path / "deck.json"
+    computed_path = computed_sidecar_path(deck_path)
+    write_deck(deck_path, make_deck(revision=1, content="First"))
+    write_computed_deck(str(deck_path), make_deck(revision=1, content="First"))
+
+    watcher = SidecarWatcher(
+        deck_path,
+        lambda payload: asyncio.sleep(0),
+        watched_path=computed_path,
+    )
+
+    assert watcher.matches_event(FileModifiedEvent(str(computed_path)))
+    assert not watcher.matches_event(FileModifiedEvent(str(deck_path)))
+
+
+def test_sidecar_watcher_detects_computed_only_changes_without_revision_bump(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        deck_path = tmp_path / "deck.json"
+        deck = make_deck(revision=1, content="First")
+        write_deck(deck_path, deck)
+        write_computed_deck(str(deck_path), deck)
+        seen_x: list[float] = []
+
+        async def on_revision_change(payload: dict[str, object]) -> None:
+            slide = payload["slides"][0]
+            computed = slide["computed"]["n-1"]
+            seen_x.append(float(computed["x"]))
+
+        watcher = SidecarWatcher(
+            deck_path,
+            on_revision_change,
+            watched_path=computed_sidecar_path(deck_path),
+            debounce_ms=50,
+        )
+        await watcher.start()
+        try:
+            deck.slides[0].computed["n-1"].x = 144.0
+            write_computed_deck(str(deck_path), deck)
+
+            await asyncio.wait_for(_wait_for(lambda: seen_x == [144.0]), timeout=1.0)
+        finally:
+            await watcher.stop()
+
+    asyncio.run(scenario())
+
+
+def test_preview_server_watches_computed_sidecar(tmp_path: Path) -> None:
+    deck_path = tmp_path / "deck.json"
+    server = PreviewServer(deck_path, port=0)
+
+    assert server._watcher.sidecar_path == deck_path.resolve()
+    assert server._watcher.watched_path == computed_sidecar_path(deck_path).resolve()
+
+
 def test_load_deck_payload_hydrates_icon_paths_for_preview(tmp_path: Path) -> None:
     deck_path = tmp_path / "deck.json"
     write_deck(deck_path, make_icon_preview_deck(revision=1))
@@ -560,7 +616,9 @@ def test_preview_server_serves_http_and_pushes_websocket_updates(
                     {"index": 0, "url": "/slides/0.png?rev=1", "revision": 1}
                 ]
 
-                write_deck(deck_path, make_deck(revision=2, content="Updated"))
+                updated_deck = make_deck(revision=2, content="Updated")
+                write_deck(deck_path, updated_deck)
+                write_computed_deck(str(deck_path), updated_deck)
 
                 rendering_one = json.loads(await asyncio.wait_for(client_one.recv(), timeout=1.0))
                 rendering_two = json.loads(await asyncio.wait_for(client_two.recv(), timeout=1.0))
@@ -680,7 +738,9 @@ def test_preview_server_waits_for_missing_deck_and_recovers_when_file_appears(
                 assert initial["deck"]["status"] == "waiting"
                 assert initial["deck"]["message"] == "Waiting for deck..."
 
-                write_deck(deck_path, make_deck(revision=1, content="Deck arrived"))
+                arrived_deck = make_deck(revision=1, content="Deck arrived")
+                write_deck(deck_path, arrived_deck)
+                write_computed_deck(str(deck_path), arrived_deck)
 
                 rendering = json.loads(await asyncio.wait_for(client.recv(), timeout=1.0))
                 updated = json.loads(await asyncio.wait_for(client.recv(), timeout=1.0))

--- a/tests/test_preview_e2e.py
+++ b/tests/test_preview_e2e.py
@@ -8,6 +8,7 @@ from typing import Any
 from websockets.asyncio.client import connect
 
 from agent_slides.commands.mutations import apply_mutation
+from agent_slides.io import read_deck, write_computed_deck
 from agent_slides.io.sidecar import init_deck, mutate_deck
 from agent_slides.model import Deck
 from agent_slides.model.layout_provider import LayoutProvider
@@ -35,6 +36,33 @@ def test_file_watcher_detects_sidecar_mutation(tmp_path: Path) -> None:
         assert payload["slides"] == [
             {"index": 0, "url": "/slides/0.png?rev=3", "revision": 3}
         ]
+
+    asyncio.run(scenario())
+
+
+def test_preview_server_updates_for_computed_only_write(tmp_path: Path) -> None:
+    async def scenario() -> None:
+        deck_path = prepare_deck(tmp_path)
+        renderer = FakeSlideRenderer(deck_path, deck_path.parent / "rendered")
+
+        async with make_server(deck_path, slide_renderer=renderer) as server:
+            async with connect(server.url) as websocket:
+                initial = await receive_update(websocket)
+                deck = read_deck(str(deck_path))
+                computed = next(iter(deck.slides[0].computed.values()))
+                computed.x += 24.0
+                write_computed_deck(str(deck_path), deck)
+                rendering = await receive_update(websocket)
+                payload = await receive_update(websocket)
+
+        assert initial["type"] == "slides_updated"
+        assert initial["revision"] == 2
+        assert rendering == {"type": "rendering", "path": str(deck_path), "slide_index": 1, "total": 1}
+        assert payload["type"] == "slides_updated"
+        assert payload["revision"] == initial["revision"]
+        assert renderer.render_indices_calls == [[0]]
+        assert server._preview_payload is not None
+        assert server._preview_payload["slides"][0]["computed"]["n-1"]["x"] == computed.x
 
     asyncio.run(scenario())
 


### PR DESCRIPTION
## Summary
- watch `deck.computed.json` for preview refreshes while still loading payloads from `deck.json`
- detect computed-only payload changes so `build` and other reflow-only writes publish updates and rerender PNG previews
- add regression coverage for computed-sidecar watching and computed-only preview updates

Fixes #210