### PR TITLE
Generate template variants for 4+ peer placeholders

### DIFF
--- a/src/agent_slides/model/template_layouts.py
+++ b/src/agent_slides/model/template_layouts.py
@@ -471,6 +471,16 @@ def _copy_slot(slot: SlotDef, **updates: Any) -> SlotDef:
     return slot.model_copy(update=updates)
 
 
+_COLUMN_VARIANT_NAMES = {
+    2: "two_col",
+    3: "three_col",
+    4: "four_col",
+    5: "five_col",
+    6: "six_col",
+}
+_MAX_COLUMN_VARIANTS = max(_COLUMN_VARIANT_NAMES)
+
+
 def _is_valid_variant(*, heading: SlotDef, bodies: list[SlotDef], theme: Theme) -> bool:
     from agent_slides.engine.constraints import constraints_from_layout, solve
     from agent_slides.engine.layout_validator import validate_layout
@@ -531,64 +541,30 @@ def _generate_variants(layout: LayoutDef, theme: Theme) -> list[LayoutDef]:
             )
         )
 
-    if len(body_slots) >= 2 and _is_valid_variant(heading=heading, bodies=body_slots[:2], theme=theme):
-        two_col_slots = {
-            "heading": _copy_slot(heading, peer_group=None, alignment_group="top", reading_order=0, size_policy="fit_content"),
-            "col1": _copy_slot(
-                body_slots[0],
-                peer_group="columns",
-                alignment_group="content",
-                reading_order=1,
-                size_policy="fill_remaining",
-            ),
-            "col2": _copy_slot(
-                body_slots[1],
-                peer_group="columns",
-                alignment_group="content",
-                reading_order=2,
-                size_policy="fill_remaining",
-            ),
-        }
-        variants.append(
-            LayoutDef(
-                name="two_col",
-                slots=two_col_slots,
-                grid=_TEMPLATE_GRID,
-                text_fitting=_variant_text_fitting(two_col_slots),
-            )
-        )
+    for count in range(2, min(len(body_slots), _MAX_COLUMN_VARIANTS) + 1):
+        column_bodies = body_slots[:count]
+        if not _is_valid_variant(heading=heading, bodies=column_bodies, theme=theme):
+            continue
 
-    if len(body_slots) >= 3 and _is_valid_variant(heading=heading, bodies=body_slots[:3], theme=theme):
-        three_col_slots = {
+        column_slots = {
             "heading": _copy_slot(heading, peer_group=None, alignment_group="top", reading_order=0, size_policy="fit_content"),
-            "col1": _copy_slot(
-                body_slots[0],
-                peer_group="columns",
-                alignment_group="content",
-                reading_order=1,
-                size_policy="fill_remaining",
-            ),
-            "col2": _copy_slot(
-                body_slots[1],
-                peer_group="columns",
-                alignment_group="content",
-                reading_order=2,
-                size_policy="fill_remaining",
-            ),
-            "col3": _copy_slot(
-                body_slots[2],
-                peer_group="columns",
-                alignment_group="content",
-                reading_order=3,
-                size_policy="fill_remaining",
-            ),
+            **{
+                f"col{index}": _copy_slot(
+                    body_slot,
+                    peer_group="columns",
+                    alignment_group="content",
+                    reading_order=index,
+                    size_policy="fill_remaining",
+                )
+                for index, body_slot in enumerate(column_bodies, start=1)
+            },
         }
         variants.append(
             LayoutDef(
-                name="three_col",
-                slots=three_col_slots,
+                name=_COLUMN_VARIANT_NAMES[count],
+                slots=column_slots,
                 grid=_TEMPLATE_GRID,
-                text_fitting=_variant_text_fitting(three_col_slots),
+                text_fitting=_variant_text_fitting(column_slots),
             )
         )
 

--- a/tests/test_template_layouts.py
+++ b/tests/test_template_layouts.py
@@ -272,6 +272,25 @@ def test_template_layout_registry_generates_semantic_variants_for_peer_bodies(tm
     assert list(variants[1].slots) == ["heading", "col1", "col2", "col3"]
 
 
+def test_template_layout_registry_generates_four_column_variant_for_peer_bodies(tmp_path: Path) -> None:
+    manifest_path = _build_variant_manifest(
+        tmp_path,
+        body_bounds=[
+            {"x": 72, "y": 156, "w": 126, "h": 220},
+            {"x": 216, "y": 156, "w": 126, "h": 220},
+            {"x": 360, "y": 156, "w": 126, "h": 220},
+            {"x": 504, "y": 156, "w": 126, "h": 220},
+        ],
+    )
+    registry = TemplateLayoutRegistry(str(manifest_path))
+
+    variants = registry.get_variants("peer_bodies")
+
+    assert [variant.name for variant in variants] == ["two_col", "three_col", "four_col"]
+    assert list(variants[-1].slots) == ["heading", "col1", "col2", "col3", "col4"]
+    assert all(variants[-1].slots[f"col{index}"].peer_group == "columns" for index in range(1, 5))
+
+
 def test_template_layout_registry_skips_variants_when_peer_invariants_fail(tmp_path: Path) -> None:
     manifest_path = _build_variant_manifest(
         tmp_path,


### PR DESCRIPTION
## Summary
- replace hard-coded 2/3-column template variant generation with a capped loop up to 6 columns
- preserve existing `title_content`, `two_col`, and `three_col` behavior while adding `four_col`+ variants with `col1..colN` slots
- add regression coverage for a 4-peer placeholder template layout

## Validation
- `UV_CACHE_DIR=.uv-cache uv run pytest -q tests/test_template_layouts.py tests/test_template_reflow.py tests/test_e2e_template.py`
- `UV_CACHE_DIR=.uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=.uv-cache uv run pytest -v`

Closes #219