### PR TITLE
Fix template placeholder computed font sizing

### DIFF
--- a/src/agent_slides/io/pptx_writer.py
+++ b/src/agent_slides/io/pptx_writer.py
@@ -172,15 +172,34 @@ def _set_run_strikethrough(run, enabled: bool) -> None:
         del rPr.attrib["strike"]
 
 
-def _apply_template_run_styles(run, run_spec: TextRun) -> None:
+def _apply_template_run_styles(
+    run,
+    run_spec: TextRun,
+    *,
+    computed: ComputedNode | None = None,
+    block: TextBlock | None = None,
+    default_font_size: float | None = None,
+) -> None:
+    if computed is not None:
+        if computed.font_family:
+            run.font.name = computed.font_family
+        if block is not None:
+            run.font.size = Pt(
+                _run_font_size(
+                    computed,
+                    block,
+                    run_spec,
+                    default_font_size=default_font_size,
+                )
+            )
+    elif run_spec.font_size is not None:
+        run.font.size = Pt(run_spec.font_size)
     if run_spec.bold is not None:
         run.font.bold = run_spec.bold
     if run_spec.italic is not None:
         run.font.italic = run_spec.italic
     if run_spec.color:
         run.font.color.rgb = hex_to_rgb(run_spec.color)
-    if run_spec.font_size is not None:
-        run.font.size = Pt(run_spec.font_size)
     if run_spec.underline:
         run.font.underline = True
     if run_spec.strikethrough:
@@ -333,15 +352,15 @@ def _node_paragraphs(
     node: Node,
     *,
     conditional_formatting: ConditionalFormatting | None = None,
-) -> list[tuple[TextBlock, list[TextRun]]]:
+) -> list[tuple[int, TextBlock, list[TextRun]]]:
     if isinstance(node.content, str):
         block = TextBlock(type="paragraph", text=node.content)
-        return [(block, line_runs) for line_runs in _block_line_runs(block, conditional_formatting)]
+        return [(0, block, line_runs) for line_runs in _block_line_runs(block, conditional_formatting)]
 
-    paragraphs: list[tuple[TextBlock, list[TextRun]]] = []
-    for block in node.content.blocks:
-        paragraphs.extend((block, line_runs) for line_runs in _block_line_runs(block, conditional_formatting))
-    return paragraphs or [(TextBlock(type="paragraph", text=""), [TextRun(text="")])]
+    paragraphs: list[tuple[int, TextBlock, list[TextRun]]] = []
+    for block_index, block in enumerate(node.content.blocks):
+        paragraphs.extend((block_index, block, line_runs) for line_runs in _block_line_runs(block, conditional_formatting))
+    return paragraphs or [(0, TextBlock(type="paragraph", text=""), [TextRun(text="")])]
 
 
 def _configure_paragraph_bullets(paragraph, block: TextBlock, *, computed: ComputedNode | None = None) -> None:
@@ -651,6 +670,7 @@ def _fill_placeholder(
     slot_mapping: dict[str, int],
     slide,
     *,
+    computed: ComputedNode | None = None,
     conditional_formatting: ConditionalFormatting | None = None,
 ) -> None:
     if node.slot_binding is None or node.type != "text":
@@ -665,13 +685,26 @@ def _fill_placeholder(
     text_frame.clear()
 
     paragraphs = _node_paragraphs(node, conditional_formatting=conditional_formatting)
-    for paragraph_index, (block, line_runs) in enumerate(paragraphs):
+    positions_by_index = (
+        {position.block_index: position for position in computed.block_positions}
+        if computed is not None and computed.block_positions
+        else {}
+    )
+
+    for paragraph_index, (block_index, block, line_runs) in enumerate(paragraphs):
         paragraph = text_frame.paragraphs[0] if paragraph_index == 0 else text_frame.add_paragraph()
-        _configure_paragraph_bullets(paragraph, block)
+        _configure_paragraph_bullets(paragraph, block, computed=computed)
+        position = positions_by_index.get(block_index)
         for run_spec in line_runs:
             run = paragraph.add_run()
             run.text = run_spec.text
-            _apply_template_run_styles(run, run_spec)
+            _apply_template_run_styles(
+                run,
+                run_spec,
+                computed=computed,
+                block=block,
+                default_font_size=position.font_size_pt if position is not None else None,
+            )
 
 
 def _write_template_pptx(deck: Deck, output_path: str) -> None:
@@ -707,6 +740,7 @@ def _write_template_pptx(deck: Deck, output_path: str) -> None:
                 node,
                 binding.slot_mapping,
                 pptx_slide,
+                computed=slide.computed.get(node.node_id),
                 conditional_formatting=conditional_formatting,
             )
 

--- a/tests/test_e2e_template.py
+++ b/tests/test_e2e_template.py
@@ -5,8 +5,10 @@ from pathlib import Path
 from xml.etree import ElementTree as ET
 from zipfile import ZipFile
 
+import pytest
 from click.testing import CliRunner, Result
 from pptx import Presentation
+from pptx.util import Pt
 
 from agent_slides.cli import cli
 from agent_slides.errors import TEMPLATE_CHANGED
@@ -37,6 +39,14 @@ def collect_text_values(path: Path) -> list[str]:
             if shape.has_text_frame:
                 values.append(shape.text_frame.text)
     return values
+
+
+def layout_by_slug(manifest: dict[str, object], slug: str) -> dict[str, object]:
+    for master in manifest["slide_masters"]:
+        for layout in master["layouts"]:
+            if layout["slug"] == slug:
+                return layout
+    raise AssertionError(f"Layout {slug} not found")
 
 
 def create_test_template(path: Path, layouts: dict[int, str] | None = None) -> None:
@@ -309,3 +319,76 @@ def test_multi_layout_template(tmp_path: Path) -> None:
         "Two Content",
         "Blank",
     ]
+
+
+def test_template_build_applies_computed_font_sizes_to_placeholder_text(tmp_path: Path) -> None:
+    template_path = tmp_path / "brand-template.pptx"
+    create_test_template(template_path)
+
+    learn_result = invoke(["learn", str(template_path)])
+    assert learn_result.exit_code == 0
+    manifest_path = tmp_path / "brand-template.manifest.json"
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    title_layout = layout_by_slug(manifest, "title_slide")
+    two_content_layout = layout_by_slug(manifest, "two_content")
+
+    deck_path = tmp_path / "deck.json"
+    init_result = invoke(["init", str(deck_path), "--template", str(manifest_path)])
+    assert init_result.exit_code == 0
+
+    for layout in ["title_slide", "two_content"]:
+        slide_add_result = invoke(["slide", "add", str(deck_path), "--layout", layout])
+        assert slide_add_result.exit_code == 0
+
+    slot_updates = [
+        (
+            "0",
+            "heading",
+            "A very long template title that should shrink to stay inside the learned title placeholder bounds",
+        ),
+        (
+            "1",
+            "col1",
+            "Point A\nPoint B\nPoint C\nPoint D\nPoint E\nPoint F\nPoint G\nPoint H",
+        ),
+    ]
+    for slide_ref, slot_name, text in slot_updates:
+        slot_result = invoke(
+            [
+                "slot",
+                "set",
+                str(deck_path),
+                "--slide",
+                slide_ref,
+                "--slot",
+                slot_name,
+                "--text",
+                text,
+            ]
+        )
+        assert slot_result.exit_code == 0
+
+    output_path = tmp_path / "deck-font-sizes.pptx"
+    build_result = invoke(["build", str(deck_path), "-o", str(output_path)])
+    assert build_result.exit_code == 0
+    assert json.loads(build_result.output)["ok"] is True
+
+    deck_payload = json.loads(deck_path.read_text(encoding="utf-8"))
+    computed_payload = json.loads((tmp_path / "deck.computed.json").read_text(encoding="utf-8"))
+    title_node_id = next(
+        node["node_id"] for node in deck_payload["slides"][0]["nodes"] if node.get("slot_binding") == "heading"
+    )
+    body_node_id = next(
+        node["node_id"] for node in deck_payload["slides"][1]["nodes"] if node.get("slot_binding") == "col1"
+    )
+    title_font_size = computed_payload["slides"][0]["computed"][title_node_id]["font_size_pt"]
+    body_font_size = computed_payload["slides"][1]["computed"][body_node_id]["font_size_pt"]
+
+    presentation = Presentation(str(output_path))
+    title_run = presentation.slides[0].placeholders[title_layout["slot_mapping"]["heading"]].text_frame.paragraphs[0].runs[0]
+    body_run = presentation.slides[1].placeholders[two_content_layout["slot_mapping"]["col1"]].text_frame.paragraphs[0].runs[0]
+
+    assert title_run.font.size == Pt(title_font_size)
+    assert body_run.font.size == Pt(body_font_size)
+    assert title_run.font.size.pt == pytest.approx(title_font_size)
+    assert body_run.font.size.pt == pytest.approx(body_font_size)

--- a/tests/test_pptx_writer.py
+++ b/tests/test_pptx_writer.py
@@ -1410,6 +1410,91 @@ def test_write_pptx_clones_template_and_fills_native_placeholders(tmp_path: Path
     assert slide_parts == ["ppt/slides/slide1.xml", "ppt/slides/slide2.xml"]
 
 
+def test_write_pptx_applies_computed_font_styles_to_template_placeholders(tmp_path: Path) -> None:
+    _, manifest_path, manifest = create_template_manifest(tmp_path)
+    output_path = tmp_path / "template-font-styles.pptx"
+    body_layout = find_layout(manifest, {"heading", "body"})
+
+    deck = Deck(
+        deck_id="template-font-styles",
+        template_manifest=str(manifest_path),
+        slides=[
+            Slide(
+                slide_id="s-1",
+                layout=body_layout["slug"],
+                nodes=[
+                    Node(node_id="n-1", slot_binding="heading", type="text", content="A longer template heading"),
+                    Node(
+                        node_id="n-2",
+                        slot_binding="body",
+                        type="text",
+                        content=NodeContent(
+                            blocks=[
+                                TextBlock(
+                                    type="paragraph",
+                                    runs=[
+                                        TextRun(text="Revenue grew "),
+                                        TextRun(text="23%", bold=True, color="#1A73E8"),
+                                        TextRun(text=" driven by "),
+                                        TextRun(text="premium segment", italic=True, font_size=24, underline=True),
+                                    ],
+                                )
+                            ]
+                        ),
+                    ),
+                ],
+                computed={
+                    "n-1": ComputedNode(
+                        x=72.0,
+                        y=54.0,
+                        width=576.0,
+                        height=72.0,
+                        font_size_pt=26.0,
+                        font_family="Aptos Display",
+                        color="#112233",
+                        bg_color=None,
+                        font_bold=True,
+                        revision=1,
+                    ),
+                    "n-2": ComputedNode(
+                        x=72.0,
+                        y=144.0,
+                        width=576.0,
+                        height=180.0,
+                        font_size_pt=18.0,
+                        font_family="Aptos",
+                        color="#112233",
+                        bg_color=None,
+                        font_bold=False,
+                        revision=1,
+                    ),
+                },
+            )
+        ],
+        counters=Counters(slides=1, nodes=2),
+    )
+
+    write_pptx(deck, str(output_path))
+
+    presentation = open_presentation(output_path)
+    slide = presentation.slides[0]
+    heading_placeholder = slide.placeholders[body_layout["slot_mapping"]["heading"]]
+    body_placeholder = slide.placeholders[body_layout["slot_mapping"]["body"]]
+
+    heading_run = heading_placeholder.text_frame.paragraphs[0].runs[0]
+    body_runs = body_placeholder.text_frame.paragraphs[0].runs
+
+    assert heading_run.font.name == "Aptos Display"
+    assert heading_run.font.size == Pt(26)
+    assert body_runs[0].font.name == "Aptos"
+    assert body_runs[0].font.size == Pt(18)
+    assert body_runs[1].font.bold is True
+    assert body_runs[1].font.color.rgb == RGBColor.from_string("1A73E8")
+    assert body_runs[3].font.italic is True
+    assert body_runs[3].font.size == Pt(24)
+    assert body_runs[3].font.underline is True
+
+
 def test_write_pptx_warns_when_template_hash_changes(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     _, manifest_path, manifest = create_template_manifest(tmp_path)
     output_path = tmp_path / "hash-mismatch.pptx"


### PR DESCRIPTION
## Summary
- pass computed text styles into the template placeholder writer
- apply computed base font sizes and font families while preserving inline rich-text font-size overrides
- add unit and e2e regressions for template placeholder font sizing

Closes #217