### PR TITLE
Fix quote placeholder inversion in learned templates

### DIFF
--- a/src/agent_slides/io/pptx_writer.py
+++ b/src/agent_slides/io/pptx_writer.py
@@ -41,6 +41,7 @@ from agent_slides.model.types import (
 )
 from agent_slides.model.design_rules import ConditionalFormatting, load_design_rules
 from agent_slides.model.themes import load_theme
+from agent_slides.template_slots import normalize_template_slot_mapping
 
 BLANK_LAYOUT_INDEX = 6
 BULLET_MARGIN_STEP_PT = 18.0
@@ -336,6 +337,10 @@ def _read_layout_bindings(payload: dict[str, Any]) -> dict[str, TemplateLayoutBi
 
             slug = _require_string(layout, "slug")
             slot_mapping = _require_dict(layout, "slot_mapping")
+            slot_mapping = normalize_template_slot_mapping(
+                slot_mapping,
+                placeholders_by_idx=_index_layout_placeholders(layout.get("placeholders")),
+            )
             binding = TemplateLayoutBinding(
                 master_index=layout.get("master_index", master_position),
                 layout_index=layout.get("index", layout_position),
@@ -346,6 +351,20 @@ def _read_layout_bindings(payload: dict[str, Any]) -> dict[str, TemplateLayoutBi
             bindings[slug] = binding
 
     return bindings
+
+
+def _index_layout_placeholders(raw_placeholders: Any) -> dict[int, dict[str, Any]]:
+    if not isinstance(raw_placeholders, list):
+        return {}
+
+    placeholders_by_idx: dict[int, dict[str, Any]] = {}
+    for placeholder in raw_placeholders:
+        if not isinstance(placeholder, dict):
+            continue
+        idx = placeholder.get("idx")
+        if isinstance(idx, int) and not isinstance(idx, bool):
+            placeholders_by_idx[idx] = placeholder
+    return placeholders_by_idx
 
 
 def _node_paragraphs(

--- a/src/agent_slides/model/template_layouts.py
+++ b/src/agent_slides/model/template_layouts.py
@@ -14,6 +14,7 @@ from agent_slides.errors import AgentSlidesError, INVALID_LAYOUT, SCHEMA_ERROR
 from agent_slides.model.layouts import DEFAULT_TEXT_FITTING
 from agent_slides.model.themes import load_theme
 from agent_slides.model.types import GridDef, LayoutDef, SlotDef, TextFitting, Theme, ThemeColors, ThemeFonts, ThemeSpacing
+from agent_slides.template_slots import infer_template_slot_role, normalize_template_slot_mapping
 
 _TEMPLATE_GRID = GridDef(
     columns=1,
@@ -106,28 +107,7 @@ def _optional_string_list(mapping: dict[str, Any], *keys: str) -> list[str] | No
 
 
 def _infer_role(slot_name: str, slot_mapping: dict[str, Any]) -> str:
-    explicit = slot_mapping.get("role")
-    if isinstance(explicit, str) and explicit:
-        return explicit.lower()
-
-    placeholder_type = slot_mapping.get("type")
-    if isinstance(placeholder_type, str):
-        normalized = placeholder_type.upper()
-        if normalized == "PICTURE":
-            return "image"
-
-    lowered = slot_name.lower()
-    if lowered in {"heading", "title", "header"}:
-        return "heading"
-    if lowered in {"subheading", "subtitle"}:
-        return "body"
-    if lowered in {"quote"}:
-        return "quote"
-    if lowered in {"attribution", "credit", "citation"}:
-        return "attribution"
-    if "image" in lowered or lowered.startswith("img"):
-        return "image"
-    return "body"
+    return infer_template_slot_role(slot_name, slot_mapping)
 
 
 def _coerce_slot_mapping(
@@ -606,6 +586,7 @@ class TemplateLayoutRegistry:
             slug = _require_string(raw_layout.get("slug"), context="layout.slug")
             slot_mapping = _as_dict(raw_layout.get("slot_mapping", {}), context=f"layout[{slug!r}].slot_mapping")
             placeholders_by_idx = _coerce_placeholder_index(raw_layout.get("placeholders"), slug=slug)
+            slot_mapping = normalize_template_slot_mapping(slot_mapping, placeholders_by_idx=placeholders_by_idx)
             master_index = raw_layout.get("master_index", 0)
             layout_index = raw_layout.get("index", 0)
             if isinstance(master_index, bool) or not isinstance(master_index, int):

--- a/src/agent_slides/template_slots.py
+++ b/src/agent_slides/template_slots.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+import re
+from typing import Any, Mapping
+
+_LABEL_SPLIT_PATTERN = re.compile(r"[^a-z0-9]+")
+_ROLE_SIZE_VALIDATIONS = (("quote", "attribution"),)
+
+
+def infer_template_slot_role(slot_name: str, slot_mapping: Mapping[str, Any]) -> str:
+    explicit = slot_mapping.get("role")
+    if isinstance(explicit, str) and explicit:
+        return explicit.lower()
+
+    placeholder_type = slot_mapping.get("type")
+    if isinstance(placeholder_type, str) and placeholder_type.upper() == "PICTURE":
+        return "image"
+
+    for candidate in (slot_name, slot_mapping.get("name")):
+        role = _role_from_label(candidate)
+        if role is not None:
+            return role
+
+    return "body"
+
+
+def normalize_template_slot_mapping(
+    slot_mapping: Mapping[str, Any],
+    *,
+    placeholders_by_idx: Mapping[int, Mapping[str, Any]],
+) -> dict[str, Any]:
+    normalized = dict(slot_mapping)
+
+    for primary_role, secondary_role in _ROLE_SIZE_VALIDATIONS:
+        primary_slot_names = _slots_for_role(normalized, placeholders_by_idx, primary_role)
+        secondary_slot_names = _slots_for_role(normalized, placeholders_by_idx, secondary_role)
+        if len(primary_slot_names) != 1 or len(secondary_slot_names) != 1:
+            continue
+
+        primary_slot = primary_slot_names[0]
+        secondary_slot = secondary_slot_names[0]
+        primary_area = _slot_area(normalized[primary_slot], placeholders_by_idx)
+        secondary_area = _slot_area(normalized[secondary_slot], placeholders_by_idx)
+        if primary_area is None or secondary_area is None:
+            continue
+        if primary_area < secondary_area:
+            normalized[primary_slot], normalized[secondary_slot] = (
+                normalized[secondary_slot],
+                normalized[primary_slot],
+            )
+
+    return normalized
+
+
+def _slots_for_role(
+    slot_mapping: Mapping[str, Any],
+    placeholders_by_idx: Mapping[int, Mapping[str, Any]],
+    role: str,
+) -> list[str]:
+    slot_names: list[str] = []
+    for slot_name, raw_slot in slot_mapping.items():
+        if infer_template_slot_role(slot_name, _resolve_slot_mapping(raw_slot, placeholders_by_idx)) == role:
+            slot_names.append(slot_name)
+    return slot_names
+
+
+def _resolve_slot_mapping(
+    raw_slot: Any,
+    placeholders_by_idx: Mapping[int, Mapping[str, Any]],
+) -> dict[str, Any]:
+    if isinstance(raw_slot, int) and not isinstance(raw_slot, bool):
+        placeholder = placeholders_by_idx.get(raw_slot)
+        if placeholder is not None:
+            return dict(placeholder)
+        return {"idx": raw_slot}
+    if isinstance(raw_slot, Mapping):
+        return dict(raw_slot)
+    return {}
+
+
+def _slot_area(raw_slot: Any, placeholders_by_idx: Mapping[int, Mapping[str, Any]]) -> float | None:
+    slot_mapping = _resolve_slot_mapping(raw_slot, placeholders_by_idx)
+    bounds = slot_mapping.get("bounds", slot_mapping)
+    if not isinstance(bounds, Mapping):
+        return None
+
+    width = _coerce_number(bounds.get("width", bounds.get("w")))
+    height = _coerce_number(bounds.get("height", bounds.get("h")))
+    if width is None or height is None:
+        return None
+    return width * height
+
+
+def _coerce_number(value: Any) -> float | None:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    return float(value)
+
+
+def _role_from_label(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    lowered = value.strip().lower()
+    if lowered in {"heading", "title", "header"}:
+        return "heading"
+    if lowered in {"subheading", "subtitle"}:
+        return "body"
+    if lowered in {"quote"}:
+        return "quote"
+    if lowered in {"attribution", "credit", "citation"}:
+        return "attribution"
+    if "image" in lowered or lowered.startswith("img"):
+        return "image"
+
+    tokens = {token for token in _LABEL_SPLIT_PATTERN.split(lowered) if token}
+    if "quote" in tokens:
+        return "quote"
+    if tokens & {"attribution", "credit", "citation"}:
+        return "attribution"
+    if "image" in tokens or "img" in tokens:
+        return "image"
+    return None

--- a/tests/test_e2e_template.py
+++ b/tests/test_e2e_template.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 from pathlib import Path
 from xml.etree import ElementTree as ET
@@ -320,7 +321,6 @@ def test_multi_layout_template(tmp_path: Path) -> None:
         "Blank",
     ]
 
-
 def test_template_build_applies_computed_font_sizes_to_placeholder_text(tmp_path: Path) -> None:
     template_path = tmp_path / "brand-template.pptx"
     create_test_template(template_path)
@@ -392,3 +392,106 @@ def test_template_build_applies_computed_font_sizes_to_placeholder_text(tmp_path
     assert body_run.font.size == Pt(body_font_size)
     assert title_run.font.size.pt == pytest.approx(title_font_size)
     assert body_run.font.size.pt == pytest.approx(body_font_size)
+
+
+def test_template_build_swaps_inverted_quote_and_attribution_placeholders(tmp_path: Path) -> None:
+    template_path = tmp_path / "quote-template.pptx"
+    create_test_template(template_path)
+
+    manifest_path = tmp_path / "quote-template.manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "source": "quote-template.pptx",
+                "source_hash": hashlib.sha256(template_path.read_bytes()).hexdigest(),
+                "theme": {
+                    "colors": {
+                        "primary": "#112233",
+                        "secondary": "#445566",
+                        "accent": "#778899",
+                        "text": "#101010",
+                        "heading_text": "#202020",
+                        "subtle_text": "#E5E7EB",
+                        "background": "#FAFAFA",
+                    },
+                    "fonts": {
+                        "heading": "Aptos Display",
+                        "body": "Aptos",
+                    },
+                    "spacing": {
+                        "base_unit": 10.0,
+                        "margin": 60.0,
+                        "gutter": 20.0,
+                    },
+                },
+                "slide_masters": [
+                    {
+                        "index": 0,
+                        "name": "Slide Master 1",
+                        "layouts": [
+                            {
+                                "index": 0,
+                                "master_index": 0,
+                                "name": "Title Slide",
+                                "slug": "quote_layout",
+                                "usable": True,
+                                "placeholders": [
+                                    {
+                                        "idx": 0,
+                                        "type": "BODY",
+                                        "name": "Large Quote",
+                                        "bounds": {"x": 72, "y": 96, "w": 576, "h": 240},
+                                    },
+                                    {
+                                        "idx": 1,
+                                        "type": "BODY",
+                                        "name": "Small Attribution",
+                                        "bounds": {"x": 72, "y": 360, "w": 576, "h": 48},
+                                    },
+                                ],
+                                "slot_mapping": {
+                                    "quote": 1,
+                                    "attribution": 0,
+                                },
+                            }
+                        ],
+                    }
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+
+    deck_path = tmp_path / "deck.json"
+    init_result = invoke(["init", str(deck_path), "--template", str(manifest_path)])
+    assert init_result.exit_code == 0
+
+    slide_add_result = invoke(["slide", "add", str(deck_path), "--layout", "quote_layout"])
+    assert slide_add_result.exit_code == 0
+
+    for slot_name, text in [("quote", "Stay hungry, stay foolish."), ("attribution", "Steve Jobs")]:
+        slot_result = invoke(
+            [
+                "slot",
+                "set",
+                str(deck_path),
+                "--slide",
+                "0",
+                "--slot",
+                slot_name,
+                "--text",
+                text,
+            ]
+        )
+        assert slot_result.exit_code == 0
+
+    output_path = tmp_path / "quote-deck.pptx"
+    build_result = invoke(["build", str(deck_path), "-o", str(output_path)])
+    assert build_result.exit_code == 0
+    assert build_result.stderr == ""
+
+    presentation = Presentation(str(output_path))
+    slide = presentation.slides[0]
+    assert slide.placeholders[0].text_frame.text == "Stay hungry, stay foolish."
+    assert slide.placeholders[1].text_frame.text == "Steve Jobs"


### PR DESCRIPTION
## Summary
- normalize learned template slot mappings so quote/attribution pairs keep the larger placeholder bound to `quote`
- reuse the same normalization in template manifest loading and template PPTX writing
- add regression coverage for inverted quote and attribution placeholder sizes, including current template writer cases on `main`

## Validation
- `UV_CACHE_DIR=.uv-cache uv run ruff check src/ tests/`
- `UV_CACHE_DIR=.uv-cache uv run pytest -q tests/test_pptx_writer.py tests/test_learn.py tests/test_template_layouts.py tests/test_template_reflow.py tests/test_e2e_template.py`

Closes #218
