### PR TITLE
Skip image-requiring layouts when no images available

### DIFF
--- a/src/agent_slides/engine/layout_suggest.py
+++ b/src/agent_slides/engine/layout_suggest.py
@@ -6,8 +6,8 @@ from dataclasses import dataclass
 from typing import Callable
 
 from agent_slides.model.design_rules import DesignRules, load_design_rules
-from agent_slides.model.layouts import list_layouts
-from agent_slides.model.types import NodeContent, TextBlock
+from agent_slides.model.layouts import get_layout, list_layouts
+from agent_slides.model.types import LayoutDef, NodeContent, TextBlock
 
 AUTO_SUGGEST_EXCLUDED_LAYOUTS = frozenset({"closing", "quote"})
 
@@ -81,6 +81,7 @@ def suggest_layouts(
     image_count: int = 0,
     available_layouts: list[str] | None = None,
     rules: DesignRules | None = None,
+    layout_getter: Callable[[str], LayoutDef] | None = None,
 ) -> list[LayoutSuggestion]:
     """Return ranked layout suggestions for the given structured content."""
 
@@ -97,6 +98,8 @@ def suggest_layouts(
         if rule.layout not in allowed_layouts or rule.layout in suggestions:
             continue
         if not rule.matches(profile, image_count, design_rules):
+            continue
+        if image_count == 0 and _layout_requires_image(rule.layout, layout_getter):
             continue
         suggestions[rule.layout] = LayoutSuggestion(
             layout=rule.layout,
@@ -269,3 +272,15 @@ def _are_word_counts_balanced(word_counts: list[int], threshold: float) -> bool:
 
 def _block_word_count(block: TextBlock) -> int:
     return len(block.text.split())
+
+
+def _layout_requires_image(layout_name: str, layout_getter: Callable[[str], LayoutDef] | None) -> bool:
+    getter = layout_getter or get_layout
+    try:
+        layout = getter(layout_name)
+    except Exception:
+        return False
+    return any(
+        slot.role == "image" or ("image" in {c.casefold() for c in slot.allowed_content} and "text" not in {c.casefold() for c in slot.allowed_content})
+        for slot in layout.slots.values()
+    )

--- a/src/agent_slides/model/template_layouts.py
+++ b/src/agent_slides/model/template_layouts.py
@@ -492,14 +492,66 @@ def _is_valid_variant(*, heading: SlotDef, bodies: list[SlotDef], theme: Theme) 
     return not any(violation.severity == "error" for violation in validate_layout(validation_layout, rects))
 
 
+def _same_horizontal_band(left: SlotDef, right: SlotDef) -> bool:
+    if left.y is None or right.y is None:
+        return False
+    return abs(float(left.y) - float(right.y)) <= _PEER_Y_EPSILON_PT and _height_close(left, right)
+
+
+def _expand_slot_horizontally(anchor: SlotDef, peers: list[SlotDef]) -> SlotDef | None:
+    all_slots = [anchor, *peers]
+    if any(slot.x is None or slot.width is None for slot in all_slots):
+        return None
+    left = min(float(slot.x) for slot in all_slots)
+    right = max(float(slot.x) + float(slot.width) for slot in all_slots)
+    return _copy_slot(anchor, x=left, width=right - left)
+
+
+def _generate_image_free_variant(
+    heading: SlotDef,
+    body_slots: list[SlotDef],
+    image_slots: list[SlotDef],
+    theme: Theme,
+) -> LayoutDef | None:
+    if len(body_slots) != 1 or not image_slots:
+        return None
+    peer_images = [slot for slot in image_slots if _same_horizontal_band(body_slots[0], slot)]
+    if not peer_images:
+        return None
+    expanded_body = _expand_slot_horizontally(body_slots[0], peer_images)
+    if expanded_body is None or not _is_valid_variant(heading=heading, bodies=[expanded_body], theme=theme):
+        return None
+    title_content_slots = {
+        "heading": _copy_slot(heading, peer_group=None, alignment_group="top", reading_order=0, size_policy="fit_content"),
+        "body": _copy_slot(
+            expanded_body,
+            peer_group=None,
+            alignment_group="content",
+            reading_order=1,
+            size_policy="fill_remaining",
+        ),
+    }
+    return LayoutDef(
+        name="title_content",
+        slots=title_content_slots,
+        grid=_TEMPLATE_GRID,
+        text_fitting=_variant_text_fitting(title_content_slots),
+    )
+
+
 def _generate_variants(layout: LayoutDef, theme: Theme) -> list[LayoutDef]:
     heading_slots = [slot for _, slot in _reading_order(layout.slots) if slot.role == "heading"]
     body_slots = [slot for _, slot in _reading_order(layout.slots) if slot.role == "body"]
+    image_slots = [slot for _, slot in _reading_order(layout.slots) if slot.role == "image"]
     if len(heading_slots) != 1 or len(body_slots) < 1:
         return []
 
     heading = heading_slots[0]
     variants: list[LayoutDef] = []
+
+    image_free = _generate_image_free_variant(heading, body_slots, image_slots, theme)
+    if image_free is not None:
+        variants.append(image_free)
 
     if len(body_slots) == 2 and _is_valid_variant(heading=heading, bodies=[body_slots[0]], theme=theme):
         title_content_slots = {

--- a/tests/test_layout_suggest.py
+++ b/tests/test_layout_suggest.py
@@ -255,3 +255,19 @@ def test_analyze_content_tracks_heading_and_group_metadata() -> None:
     assert profile.word_count == 17
     assert profile.heading_count == 3
     assert len(profile.remaining_groups) == 2
+
+
+def test_suggest_layouts_excludes_image_layouts_when_no_images() -> None:
+    content = make_content(
+        ("heading", "Product launch"),
+        ("paragraph", "A concise overview of the launch story and results."),
+    )
+    suggestions_with_images = suggest_layouts(content, image_count=1)
+    suggestions_no_images = suggest_layouts(content, image_count=0)
+
+    image_layouts = {"gallery", "image_left", "image_right", "hero_image"}
+    with_image_names = {s.layout for s in suggestions_with_images}
+    no_image_names = {s.layout for s in suggestions_no_images}
+
+    assert with_image_names & image_layouts, "image layouts should appear when images are available"
+    assert not (no_image_names & image_layouts), "image layouts should not appear when image_count=0"

--- a/tests/test_template_layouts.py
+++ b/tests/test_template_layouts.py
@@ -334,6 +334,66 @@ def test_layout_providers_expose_get_variants_consistently(tmp_path: Path) -> No
     assert [variant.name for variant in template.get_variants("peer_bodies")] == ["title_content", "two_col"]
 
 
+def _build_mixed_text_image_manifest(base_dir: Path) -> Path:
+    template_path = base_dir / "templates" / "mixed" / "mixed-template.pptx"
+    manifest_path = base_dir / "templates" / "mixed" / "manifest.json"
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_bytes(b"pptx")
+
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "name": "mixed-template",
+                "source": "mixed-template.pptx",
+                "source_hash": "mixed123",
+                "theme": {
+                    "name": "mixed-theme",
+                    "colors": {
+                        "primary": "#101820",
+                        "secondary": "#203040",
+                        "accent": "#ff6600",
+                        "background": "#faf7f2",
+                        "text": "#1f1f1f",
+                    },
+                    "fonts": {"heading": "Aptos Display", "body": "Aptos"},
+                    "spacing": {"base_unit": 12, "margin": 48, "gutter": 18},
+                },
+                "layouts": [
+                    {
+                        "slug": "intro_with_image",
+                        "usable": True,
+                        "placeholders": [
+                            {"idx": 0, "type": "TITLE", "name": "Title", "bounds": {"x": 72, "y": 48, "w": 576, "h": 72}},
+                            {"idx": 1, "type": "BODY", "name": "Body", "bounds": {"x": 72, "y": 156, "w": 270, "h": 300}},
+                            {"idx": 2, "type": "PICTURE", "name": "Image", "bounds": {"x": 360, "y": 156, "w": 288, "h": 300}},
+                        ],
+                        "slot_mapping": {"heading": 0, "body": 1, "image": 2},
+                    }
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def test_template_layout_registry_generates_image_free_variant(tmp_path: Path) -> None:
+    manifest_path = _build_mixed_text_image_manifest(tmp_path)
+    registry = TemplateLayoutRegistry(str(manifest_path))
+
+    variants = registry.get_variants("intro_with_image")
+
+    variant_names = [variant.name for variant in variants]
+    assert "title_content" in variant_names
+
+    title_content = next(v for v in variants if v.name == "title_content")
+    assert list(title_content.slots) == ["heading", "body"]
+    body_slot = title_content.slots["body"]
+    assert body_slot.width is not None
+    assert body_slot.width > 270, "body should expand to cover the image slot's width"
+
+
 def test_mutate_deck_uses_template_layout_registry_when_manifest_is_present(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary
- Filter out image-requiring layouts in `suggest_layouts()` when `image_count == 0`
- Generate image-free `title_content` variant from mixed text+image template layouts by expanding the body slot to cover the image slot's horizontal space
- New tests for both behaviors

## Test plan
- [x] `uv run pytest -q tests/test_layout_suggest.py` — image exclusion test passes
- [x] `uv run pytest -q tests/test_template_layouts.py` — image-free variant generation test passes
- [x] `uv run pytest -q` — 379 passed (1 pre-existing flaky #209)
- [x] `uv run ruff check` — clean

Closes #220