### PR TITLE
Add layout inventory export script

### DIFF
--- a/scripts/export_layout_inventory.py
+++ b/scripts/export_layout_inventory.py
@@ -1,0 +1,303 @@
+"""Export a deterministic layout inventory from a learned manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - PyYAML is a project dependency.
+    yaml = None
+
+SLOT_STRUCTURE_VALUES = {
+    "heading_only",
+    "heading_body",
+    "heading_image",
+    "heading_body_image",
+    "multi_slot",
+    "blank",
+}
+_SLOT_PRIORITY = {
+    "heading": 0,
+    "subheading": 10,
+    "body": 20,
+    "quote": 30,
+    "attribution": 40,
+    "image": 90,
+}
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("manifest_path", type=Path)
+    parser.add_argument("--exclude-policy", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Manifest file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Manifest file is not valid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Manifest root must be a JSON object")
+    return payload
+
+
+def _load_exclude_policy(path: Path | None) -> dict[str, str]:
+    if path is None:
+        return {}
+
+    try:
+        raw_text = path.read_text(encoding="utf-8")
+    except FileNotFoundError as exc:
+        raise ValueError(f"Exclude policy file not found: {path}") from exc
+
+    if path.suffix.casefold() in {".yaml", ".yml"}:
+        if yaml is None:  # pragma: no cover
+            raise ValueError("PyYAML is required to read YAML exclude policies")
+        loaded = yaml.safe_load(raw_text)
+    else:
+        try:
+            loaded = json.loads(raw_text)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Exclude policy file is not valid JSON: {path}") from exc
+
+    if loaded is None:
+        return {}
+    if not isinstance(loaded, dict):
+        raise ValueError("Exclude policy root must be an object")
+
+    candidate = loaded.get("layouts")
+    if candidate is None:
+        candidate = loaded.get("exclude_layouts")
+    if candidate is None:
+        candidate = loaded
+    if not isinstance(candidate, dict):
+        raise ValueError("Exclude policy layout entries must be an object")
+
+    policy: dict[str, str] = {}
+    for slug, raw_reason in candidate.items():
+        if not isinstance(slug, str) or not slug.strip():
+            raise ValueError("Exclude policy slugs must be non-empty strings")
+        reason = _normalize_exclude_reason(raw_reason, slug=slug)
+        if reason is not None:
+            policy[slug.strip()] = reason
+    return policy
+
+
+def _normalize_exclude_reason(raw_reason: object, *, slug: str) -> str | None:
+    if raw_reason is None:
+        return None
+    if isinstance(raw_reason, str):
+        normalized = raw_reason.strip()
+        return normalized or None
+    if isinstance(raw_reason, dict):
+        reason = raw_reason.get("exclude_reason", raw_reason.get("reason"))
+        if reason is None:
+            return None
+        if not isinstance(reason, str):
+            raise ValueError(f"Exclude reason for '{slug}' must be a string")
+        normalized = reason.strip()
+        return normalized or None
+    raise ValueError(f"Exclude policy entry for '{slug}' must be a string, object, or null")
+
+
+def _iter_layouts(manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    if "slide_masters" in manifest:
+        slide_masters = manifest["slide_masters"]
+        if not isinstance(slide_masters, list):
+            raise ValueError("Manifest field 'slide_masters' must be a list")
+        layouts: list[dict[str, Any]] = []
+        for master_index, master in enumerate(slide_masters):
+            if not isinstance(master, dict):
+                raise ValueError(f"Manifest slide_masters[{master_index}] must be an object")
+            master_layouts = master.get("layouts", [])
+            if not isinstance(master_layouts, list):
+                raise ValueError(f"Manifest slide_masters[{master_index}].layouts must be a list")
+            for layout in master_layouts:
+                if not isinstance(layout, dict):
+                    raise ValueError("Manifest layouts must be objects")
+                layouts.append(layout)
+        return layouts
+
+    layouts = manifest.get("layouts")
+    if isinstance(layouts, list):
+        if not all(isinstance(layout, dict) for layout in layouts):
+            raise ValueError("Manifest layouts must be objects")
+        return list(layouts)
+
+    raise ValueError("Manifest must contain 'slide_masters' or 'layouts'")
+
+
+def _slot_sort_key(slot_name: str) -> tuple[int, str]:
+    if slot_name in _SLOT_PRIORITY:
+        return (_SLOT_PRIORITY[slot_name], slot_name)
+    if slot_name.startswith("col") and slot_name[3:].isdigit():
+        return (50 + int(slot_name[3:]), slot_name)
+    if "_" in slot_name:
+        prefix, _, suffix = slot_name.rpartition("_")
+        if suffix.isdigit():
+            return (70, f"{prefix}:{int(suffix):06d}")
+    return (80, slot_name)
+
+
+def _normalize_bounds(raw_bounds: object, *, context: str) -> dict[str, float]:
+    if not isinstance(raw_bounds, dict):
+        raise ValueError(f"{context} must be an object")
+
+    x = raw_bounds.get("x", raw_bounds.get("left"))
+    y = raw_bounds.get("y", raw_bounds.get("top"))
+    w = raw_bounds.get("w", raw_bounds.get("width"))
+    h = raw_bounds.get("h", raw_bounds.get("height"))
+
+    normalized: dict[str, float] = {}
+    for key, raw_value in {"x": x, "y": y, "w": w, "h": h}.items():
+        if isinstance(raw_value, bool) or not isinstance(raw_value, int | float):
+            raise ValueError(f"{context}.{key} must be numeric")
+        normalized[key] = float(raw_value)
+    return normalized
+
+
+def _placeholders_by_idx(layout: dict[str, Any]) -> dict[int, dict[str, float]]:
+    placeholders = layout.get("placeholders", [])
+    if placeholders is None:
+        return {}
+    if not isinstance(placeholders, list):
+        raise ValueError(f"Layout '{layout.get('slug', '<unknown>')}' placeholders must be a list")
+
+    resolved: dict[int, dict[str, float]] = {}
+    for placeholder in placeholders:
+        if not isinstance(placeholder, dict):
+            raise ValueError("Layout placeholders must be objects")
+        idx = placeholder.get("idx")
+        if isinstance(idx, bool) or not isinstance(idx, int):
+            raise ValueError("Layout placeholder idx must be an integer")
+        resolved[idx] = _normalize_bounds(
+            placeholder.get("bounds", placeholder),
+            context=f"layout '{layout.get('slug', '<unknown>')}' placeholder[{idx}] bounds",
+        )
+    return resolved
+
+
+def _resolve_slot_bounds(slot_name: str, raw_slot: object, *, placeholders_by_idx: dict[int, dict[str, float]]) -> dict[str, float]:
+    if isinstance(raw_slot, bool):
+        raise ValueError(f"slot_mapping[{slot_name!r}] must not be a boolean")
+    if isinstance(raw_slot, int):
+        try:
+            return dict(placeholders_by_idx[raw_slot])
+        except KeyError as exc:
+            raise ValueError(f"slot_mapping[{slot_name!r}] references missing placeholder idx {raw_slot}") from exc
+    if not isinstance(raw_slot, dict):
+        raise ValueError(f"slot_mapping[{slot_name!r}] must be an integer or object")
+    return _normalize_bounds(raw_slot.get("bounds", raw_slot), context=f"slot_mapping[{slot_name!r}] bounds")
+
+
+def _classify_slot_structure(fillable_slots: list[str]) -> str:
+    slot_names = set(fillable_slots)
+    if not slot_names:
+        return "blank"
+
+    if "heading" in slot_names and slot_names.issubset({"heading", "subheading"}):
+        return "heading_only"
+    if {"heading", "body"}.issubset(slot_names) and slot_names.issubset({"heading", "subheading", "body"}):
+        return "heading_body"
+    if {"heading", "image"}.issubset(slot_names) and slot_names.issubset({"heading", "subheading", "image"}):
+        return "heading_image"
+    if {"heading", "body", "image"}.issubset(slot_names) and slot_names.issubset(
+        {"heading", "subheading", "body", "image"}
+    ):
+        return "heading_body_image"
+    return "multi_slot"
+
+
+def _is_testable(
+    *,
+    usable: bool,
+    fillable_slots: list[str],
+    is_disclaimer_duplicate: bool,
+    exclude_reason: str | None,
+) -> bool:
+    if not usable or not fillable_slots:
+        return False
+    if is_disclaimer_duplicate or exclude_reason is not None:
+        return False
+    return True
+
+
+def build_inventory(manifest: dict[str, Any], *, exclude_policy: dict[str, str] | None = None) -> dict[str, Any]:
+    policy = exclude_policy or {}
+    layouts = _iter_layouts(manifest)
+    entries: list[dict[str, Any]] = []
+
+    for layout in layouts:
+        slug = layout.get("slug")
+        if not isinstance(slug, str) or not slug.strip():
+            raise ValueError("Every layout must include a non-empty 'slug'")
+        slot_mapping = layout.get("slot_mapping", {})
+        if not isinstance(slot_mapping, dict):
+            raise ValueError(f"Layout '{slug}' slot_mapping must be an object")
+
+        fillable_slots = sorted((str(slot_name) for slot_name in slot_mapping), key=_slot_sort_key)
+        placeholder_idx_map = _placeholders_by_idx(layout)
+        placeholder_bounds = {
+            slot_name: _resolve_slot_bounds(slot_name, slot_mapping[slot_name], placeholders_by_idx=placeholder_idx_map)
+            for slot_name in fillable_slots
+        }
+        usable = bool(layout.get("usable", bool(fillable_slots)))
+        exclude_reason = policy.get(slug)
+        is_disclaimer_duplicate = slug.startswith("d_")
+
+        entry = {
+            "slug": slug,
+            "usable": usable,
+            "requires_image": "image" in slot_mapping,
+            "is_disclaimer_duplicate": is_disclaimer_duplicate,
+            "slot_structure": _classify_slot_structure(fillable_slots),
+            "fillable_slots": fillable_slots,
+            "placeholder_bounds": placeholder_bounds,
+            "testable": _is_testable(
+                usable=usable,
+                fillable_slots=fillable_slots,
+                is_disclaimer_duplicate=is_disclaimer_duplicate,
+                exclude_reason=exclude_reason,
+            ),
+            "exclude_reason": exclude_reason,
+        }
+        if entry["slot_structure"] not in SLOT_STRUCTURE_VALUES:
+            raise ValueError(f"Unsupported slot structure generated for '{slug}'")
+        entries.append(entry)
+
+    entries.sort(key=lambda entry: str(entry["slug"]))
+    return {
+        "source": manifest.get("source"),
+        "source_hash": manifest.get("source_hash"),
+        "layout_count": len(entries),
+        "testable_count": sum(1 for entry in entries if entry["testable"]),
+        "layouts": entries,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        manifest = _load_json(args.manifest_path)
+        exclude_policy = _load_exclude_policy(args.exclude_policy)
+        inventory = build_inventory(manifest, exclude_policy=exclude_policy)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    json.dump(inventory, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_export_layout_inventory.py
+++ b/tests/test_export_layout_inventory.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from pptx import Presentation
+
+from agent_slides.io import read_template_manifest
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "export_layout_inventory.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("export_layout_inventory", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_manifest(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "source": "fixtures/demo-template.pptx",
+                "source_hash": "abc123",
+                "slide_masters": [
+                    {
+                        "index": 0,
+                        "name": "Slide Master 1",
+                        "layouts": [
+                            {
+                                "slug": "title_only",
+                                "usable": True,
+                                "placeholders": [
+                                    {"idx": 0, "bounds": {"x": 72, "y": 48, "w": 560, "h": 80}},
+                                    {"idx": 1, "bounds": {"x": 72, "y": 136, "w": 560, "h": 36}},
+                                ],
+                                "slot_mapping": {"heading": 0, "subheading": 1},
+                            },
+                            {
+                                "slug": "body_text",
+                                "usable": True,
+                                "placeholders": [
+                                    {"idx": 0, "bounds": {"x": 72, "y": 48, "w": 560, "h": 80}},
+                                    {"idx": 1, "bounds": {"x": 72, "y": 156, "w": 560, "h": 220}},
+                                ],
+                                "slot_mapping": {"heading": 0, "body": 1},
+                            },
+                            {
+                                "slug": "visual_story",
+                                "usable": True,
+                                "placeholders": [
+                                    {"idx": 0, "bounds": {"x": 72, "y": 48, "w": 560, "h": 80}},
+                                    {"idx": 1, "bounds": {"x": 360, "y": 156, "w": 288, "h": 260}},
+                                ],
+                                "slot_mapping": {"heading": 0, "image": 1},
+                            },
+                            {
+                                "slug": "mixed_story",
+                                "usable": True,
+                                "placeholders": [
+                                    {"idx": 0, "bounds": {"x": 72, "y": 48, "w": 560, "h": 80}},
+                                    {"idx": 1, "bounds": {"x": 72, "y": 156, "w": 252, "h": 260}},
+                                    {"idx": 2, "bounds": {"x": 360, "y": 156, "w": 288, "h": 260}},
+                                ],
+                                "slot_mapping": {"heading": 0, "body": 1, "image": 2},
+                            },
+                            {
+                                "slug": "three_up",
+                                "usable": True,
+                                "placeholders": [
+                                    {"idx": 0, "bounds": {"x": 72, "y": 48, "w": 560, "h": 80}},
+                                    {"idx": 1, "bounds": {"x": 72, "y": 156, "w": 160, "h": 220}},
+                                    {"idx": 2, "bounds": {"x": 256, "y": 156, "w": 160, "h": 220}},
+                                    {"idx": 3, "bounds": {"x": 440, "y": 156, "w": 160, "h": 220}},
+                                ],
+                                "slot_mapping": {"heading": 0, "col1": 1, "col2": 2, "col3": 3},
+                            },
+                            {
+                                "slug": "blankish",
+                                "usable": True,
+                                "placeholders": [],
+                                "slot_mapping": {},
+                            },
+                            {
+                                "slug": "d_body_text",
+                                "usable": True,
+                                "placeholders": [
+                                    {"idx": 0, "bounds": {"x": 72, "y": 48, "w": 560, "h": 80}},
+                                    {"idx": 1, "bounds": {"x": 72, "y": 156, "w": 560, "h": 220}},
+                                ],
+                                "slot_mapping": {"heading": 0, "body": 1},
+                            },
+                            {
+                                "slug": "dict_bounds_layout",
+                                "usable": True,
+                                "slot_mapping": {
+                                    "heading": {"bounds": {"x": 60, "y": 40, "width": 520, "height": 72}},
+                                    "body": {"bounds": {"left": 60, "top": 140, "width": 520, "height": 240}},
+                                },
+                            },
+                        ],
+                    }
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_export_layout_inventory_cli_outputs_expected_inventory(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "template.manifest.json"
+    policy_path = tmp_path / "exclude-policy.json"
+    _write_manifest(manifest_path)
+    policy_path.write_text(
+        json.dumps({"layouts": {"three_up": "manual review only"}}) + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_script(str(manifest_path), "--exclude-policy", str(policy_path))
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["source"] == "fixtures/demo-template.pptx"
+    assert payload["layout_count"] == 8
+    assert payload["testable_count"] == 5
+
+    layouts = {layout["slug"]: layout for layout in payload["layouts"]}
+    assert [layout["slug"] for layout in payload["layouts"]] == sorted(layouts)
+
+    assert layouts["title_only"]["slot_structure"] == "heading_only"
+    assert layouts["body_text"]["slot_structure"] == "heading_body"
+    assert layouts["visual_story"]["slot_structure"] == "heading_image"
+    assert layouts["mixed_story"]["slot_structure"] == "heading_body_image"
+    assert layouts["three_up"]["slot_structure"] == "multi_slot"
+    assert layouts["blankish"]["slot_structure"] == "blank"
+
+    assert layouts["mixed_story"]["requires_image"] is True
+    assert layouts["body_text"]["requires_image"] is False
+    assert layouts["d_body_text"]["is_disclaimer_duplicate"] is True
+    assert layouts["three_up"]["exclude_reason"] == "manual review only"
+    assert layouts["three_up"]["testable"] is False
+    assert layouts["blankish"]["testable"] is False
+    assert layouts["dict_bounds_layout"]["placeholder_bounds"] == {
+        "heading": {"x": 60.0, "y": 40.0, "w": 520.0, "h": 72.0},
+        "body": {"x": 60.0, "y": 140.0, "w": 520.0, "h": 240.0},
+    }
+    assert layouts["mixed_story"]["fillable_slots"] == ["heading", "body", "image"]
+
+
+def test_export_layout_inventory_output_is_deterministic(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "template.manifest.json"
+    _write_manifest(manifest_path)
+
+    first = _run_script(str(manifest_path))
+    second = _run_script(str(manifest_path))
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+    assert first.stdout == second.stdout
+
+
+def test_export_layout_inventory_supports_learned_manifests_from_multiple_templates(tmp_path: Path) -> None:
+    module = _load_script_module()
+
+    for index in range(4):
+        template_path = tmp_path / f"example-{index + 1}.pptx"
+        manifest_path = tmp_path / f"example-{index + 1}.manifest.json"
+        Presentation().save(template_path)
+        read_template_manifest(template_path, manifest_path)
+
+        payload = module.build_inventory(json.loads(manifest_path.read_text(encoding="utf-8")))
+
+        assert payload["layout_count"] > 0
+        assert payload["testable_count"] >= 0
+        assert all("slug" in layout for layout in payload["layouts"])
+        assert all("slot_structure" in layout for layout in payload["layouts"])
+
+
+def test_export_layout_inventory_rejects_missing_placeholder_references(tmp_path: Path) -> None:
+    manifest_path = tmp_path / "template.manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "source": "fixtures/demo-template.pptx",
+                "slide_masters": [
+                    {
+                        "layouts": [
+                            {
+                                "slug": "broken",
+                                "usable": True,
+                                "placeholders": [],
+                                "slot_mapping": {"heading": 99},
+                            }
+                        ]
+                    }
+                ],
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    result = _run_script(str(manifest_path))
+
+    assert result.returncode == 1
+    assert "references missing placeholder idx 99" in result.stderr


### PR DESCRIPTION
## Summary
- add `scripts/export_layout_inventory.py` to export deterministic, manifest-derived layout inventories
- support optional per-template exclude policies without hardcoded layout slug classification
- add focused tests for slot-structure classification, determinism, invalid references, and learned-manifest coverage

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache-agent-slides uv run ruff check scripts/ tests/`
- `UV_CACHE_DIR=/tmp/uv-cache-agent-slides uv run pytest -q tests/test_export_layout_inventory.py`
- generated 4 PPTX templates, ran `agent-slides learn`, then `scripts/export_layout_inventory.py` against each
- `UV_CACHE_DIR=/tmp/uv-cache-agent-slides uv run pytest -v`

Closes #229