### PR TITLE
Add slot-structure layout fixtures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,7 @@ __pycache__/
 !/.claude/skills/learn-template
 /.artifacts/
 /examples/
+!/examples/
+!/examples/images/
+!/examples/images/*.svg
 /.claude/skills/

--- a/examples/images/capacity-gap-map.svg
+++ b/examples/images/capacity-gap-map.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Capacity gap map</title>
+  <desc id="desc">A stylized consulting map showing regional service pressure.</desc>
+  <rect width="1280" height="720" fill="#F4F0E8"/>
+  <rect x="72" y="72" width="1136" height="576" rx="36" fill="#FFFDF9" stroke="#D5C6B0" stroke-width="4"/>
+  <text x="108" y="140" fill="#3C352C" font-family="Georgia, serif" font-size="40" font-weight="700">
+    Regional demand is clustered in the Southeast and Mountain corridors
+  </text>
+  <g fill="#D96B2B">
+    <circle cx="360" cy="410" r="56"/>
+    <circle cx="592" cy="456" r="44"/>
+    <circle cx="824" cy="368" r="64"/>
+    <circle cx="1008" cy="262" r="48"/>
+  </g>
+  <g fill="#184E77">
+    <circle cx="470" cy="278" r="26"/>
+    <circle cx="702" cy="224" r="20"/>
+    <circle cx="904" cy="486" r="24"/>
+  </g>
+  <g stroke="#3C352C" stroke-width="8" stroke-linecap="round">
+    <line x1="360" y1="410" x2="592" y2="456"/>
+    <line x1="592" y1="456" x2="824" y2="368"/>
+    <line x1="824" y1="368" x2="1008" y2="262"/>
+  </g>
+  <text x="108" y="612" fill="#5C5348" font-family="Arial, sans-serif" font-size="28">
+    Orange circles mark backlog hot spots. Blue circles mark stable districts.
+  </text>
+</svg>

--- a/examples/images/network-coverage.svg
+++ b/examples/images/network-coverage.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Network coverage view</title>
+  <desc id="desc">A simplified operating network graphic for service coverage.</desc>
+  <rect width="1280" height="720" fill="#EEF3EE"/>
+  <rect x="64" y="64" width="1152" height="592" rx="40" fill="#FFFFFF" stroke="#BFD2C0" stroke-width="4"/>
+  <text x="108" y="136" fill="#1C3B2A" font-family="Georgia, serif" font-size="40" font-weight="700">
+    Service coverage depends on local bench depth, not just national headcount
+  </text>
+  <g fill="#2D6A4F">
+    <rect x="168" y="232" width="180" height="92" rx="18"/>
+    <rect x="460" y="184" width="180" height="92" rx="18"/>
+    <rect x="460" y="404" width="180" height="92" rx="18"/>
+    <rect x="782" y="294" width="180" height="92" rx="18"/>
+  </g>
+  <g fill="#FFFFFF" font-family="Arial, sans-serif" font-size="28" font-weight="700" text-anchor="middle">
+    <text x="258" y="288">West hub</text>
+    <text x="550" y="240">Central routing</text>
+    <text x="550" y="460">Flex labor pool</text>
+    <text x="872" y="350">Priority markets</text>
+  </g>
+  <g stroke="#8A9F8C" stroke-width="10" stroke-linecap="round">
+    <line x1="348" y1="278" x2="460" y2="230"/>
+    <line x1="348" y1="278" x2="460" y2="450"/>
+    <line x1="640" y1="230" x2="782" y2="340"/>
+    <line x1="640" y1="450" x2="782" y2="340"/>
+  </g>
+  <text x="108" y="612" fill="#506256" font-family="Arial, sans-serif" font-size="28">
+    The diagram highlights where routing and staffing interventions converge.
+  </text>
+</svg>

--- a/examples/images/service-dashboard.svg
+++ b/examples/images/service-dashboard.svg
@@ -1,0 +1,31 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="720" viewBox="0 0 1280 720" role="img" aria-labelledby="title desc">
+  <title id="title">Service dashboard</title>
+  <desc id="desc">A dashboard-style image for operating metrics.</desc>
+  <rect width="1280" height="720" fill="#F7F3EB"/>
+  <rect x="68" y="68" width="1144" height="584" rx="32" fill="#FFFDF9" stroke="#D8CBB8" stroke-width="4"/>
+  <text x="112" y="136" fill="#2F2922" font-family="Georgia, serif" font-size="40" font-weight="700">
+    Weekly dashboard tracks service recovery against hiring and routing decisions
+  </text>
+  <g>
+    <rect x="116" y="200" width="280" height="180" rx="24" fill="#184E77"/>
+    <rect x="428" y="200" width="280" height="180" rx="24" fill="#D96B2B"/>
+    <rect x="740" y="200" width="280" height="180" rx="24" fill="#6D597A"/>
+  </g>
+  <g fill="#FFFFFF" font-family="Arial, sans-serif" text-anchor="middle">
+    <text x="256" y="254" font-size="28" font-weight="700">Backlog days</text>
+    <text x="256" y="332" font-size="64" font-weight="700">8.4</text>
+    <text x="568" y="254" font-size="28" font-weight="700">Hiring fill rate</text>
+    <text x="568" y="332" font-size="64" font-weight="700">72%</text>
+    <text x="880" y="254" font-size="28" font-weight="700">First-time fix</text>
+    <text x="880" y="332" font-size="64" font-weight="700">91%</text>
+  </g>
+  <g fill="#C9B89F">
+    <rect x="116" y="432" width="904" height="132" rx="24"/>
+  </g>
+  <g stroke="#2F2922" stroke-width="10" fill="none" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M164 516 L300 494 L430 520 L558 460 L690 470 L822 438 L970 454"/>
+  </g>
+  <text x="112" y="612" fill="#5D5447" font-family="Arial, sans-serif" font-size="28">
+    The dashboard mockup gives image slot structures a checked-in visual asset.
+  </text>
+</svg>

--- a/fixtures/layout_cases/heading_body.json
+++ b/fixtures/layout_cases/heading_body.json
@@ -1,0 +1,137 @@
+{
+  "dense_body": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Implications",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Backlog exceeds the ten-day threshold in six priority metros.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Travel time inflation is eroding technician utilization by roughly one shift per week.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Attrition remains elevated where supervisors manage both dispatch and field coaching.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Actions underway",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Leadership is staging targeted hiring against the highest-margin territories first.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Routing rules are being reset to reduce cross-district spillover.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Weekly performance reviews now compare service-level recovery against hiring conversion.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    }
+  },
+  "long_heading": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand grew 14% year on year while field capacity expanded only 6%, leaving recurring coverage gaps in select metros.",
+          "type": "paragraph"
+        },
+        {
+          "level": 0,
+          "text": "Eight priority markets account for most of the open service backlog.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Utilization improves quickly when routing is reset at the district level.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Regional demand has accelerated faster than workforce capacity, forcing leaders to rebalance coverage before service levels deteriorate further",
+          "type": "heading"
+        }
+      ]
+    }
+  },
+  "narrow_safe": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Close the backlog before expanding coverage.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Stabilize priority markets",
+          "type": "heading"
+        }
+      ]
+    }
+  },
+  "nominal": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand grew 14% year on year while field capacity expanded only 6%, leaving recurring coverage gaps in select metros.",
+          "type": "paragraph"
+        },
+        {
+          "level": 0,
+          "text": "Eight priority markets account for most of the open service backlog.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Utilization improves quickly when routing is reset at the district level.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    }
+  }
+}

--- a/fixtures/layout_cases/heading_body_image.json
+++ b/fixtures/layout_cases/heading_body_image.json
@@ -1,0 +1,217 @@
+{
+  "dense_body": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Implications",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Backlog exceeds the ten-day threshold in six priority metros.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Travel time inflation is eroding technician utilization by roughly one shift per week.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Attrition remains elevated where supervisors manage both dispatch and field coaching.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Actions underway",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Leadership is staging targeted hiring against the highest-margin territories first.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Routing rules are being reset to reduce cross-district spillover.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Weekly performance reviews now compare service-level recovery against hiring conversion.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/capacity-gap-map.svg"
+    }
+  },
+  "image_missing": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand grew 14% year on year while field capacity expanded only 6%, leaving recurring coverage gaps in select metros.",
+          "type": "paragraph"
+        },
+        {
+          "level": 0,
+          "text": "Eight priority markets account for most of the open service backlog.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Utilization improves quickly when routing is reset at the district level.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Text-only fallback keeps the storyline usable when visual assets are unavailable",
+          "type": "heading"
+        }
+      ]
+    }
+  },
+  "image_present": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand grew 14% year on year while field capacity expanded only 6%, leaving recurring coverage gaps in select metros.",
+          "type": "paragraph"
+        },
+        {
+          "level": 0,
+          "text": "Eight priority markets account for most of the open service backlog.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Utilization improves quickly when routing is reset at the district level.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/network-coverage.svg"
+    }
+  },
+  "long_heading": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand grew 14% year on year while field capacity expanded only 6%, leaving recurring coverage gaps in select metros.",
+          "type": "paragraph"
+        },
+        {
+          "level": 0,
+          "text": "Eight priority markets account for most of the open service backlog.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Utilization improves quickly when routing is reset at the district level.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Regional demand has accelerated faster than workforce capacity, forcing leaders to rebalance coverage before service levels deteriorate further",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/capacity-gap-map.svg"
+    }
+  },
+  "narrow_safe": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Close the backlog before expanding coverage.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Stabilize priority markets",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/capacity-gap-map.svg"
+    }
+  },
+  "nominal": {
+    "body": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand grew 14% year on year while field capacity expanded only 6%, leaving recurring coverage gaps in select metros.",
+          "type": "paragraph"
+        },
+        {
+          "level": 0,
+          "text": "Eight priority markets account for most of the open service backlog.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Utilization improves quickly when routing is reset at the district level.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/capacity-gap-map.svg"
+    }
+  }
+}

--- a/fixtures/layout_cases/heading_image.json
+++ b/fixtures/layout_cases/heading_image.json
@@ -1,0 +1,73 @@
+{
+  "image_missing": {
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Text-only fallback keeps the storyline usable when visual assets are unavailable",
+          "type": "heading"
+        }
+      ]
+    }
+  },
+  "image_present": {
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/network-coverage.svg"
+    }
+  },
+  "long_heading": {
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Regional demand has accelerated faster than workforce capacity, forcing leaders to rebalance coverage before service levels deteriorate further",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/capacity-gap-map.svg"
+    }
+  },
+  "narrow_safe": {
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Stabilize priority markets",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/capacity-gap-map.svg"
+    }
+  },
+  "nominal": {
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    },
+    "image": {
+      "image_fit": "cover",
+      "image_path": "examples/images/capacity-gap-map.svg"
+    }
+  }
+}

--- a/fixtures/layout_cases/heading_only.json
+++ b/fixtures/layout_cases/heading_only.json
@@ -1,0 +1,62 @@
+{
+  "long_heading": {
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Regional demand has accelerated faster than workforce capacity, forcing leaders to rebalance coverage before service levels deteriorate further",
+          "type": "heading"
+        }
+      ]
+    },
+    "subheading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "The imbalance is sharpest where demand spikes collided with slower technician hiring.",
+          "type": "paragraph"
+        }
+      ]
+    }
+  },
+  "narrow_safe": {
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Stabilize priority markets",
+          "type": "heading"
+        }
+      ]
+    },
+    "subheading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Focus on the six markets with the largest backlog.",
+          "type": "paragraph"
+        }
+      ]
+    }
+  },
+  "nominal": {
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    },
+    "subheading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "The imbalance is sharpest where demand spikes collided with slower technician hiring.",
+          "type": "paragraph"
+        }
+      ]
+    }
+  }
+}

--- a/fixtures/layout_cases/multi_slot.json
+++ b/fixtures/layout_cases/multi_slot.json
@@ -1,0 +1,289 @@
+{
+  "dense_body": {
+    "col1": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand hot spots",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Revenue exposure is highest in locations with the thinnest bench.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Supervisors are reallocating senior technicians to stabilize first-time fix rates.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "The queue length falls fastest when dispatch locks same-day overflow windows.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Decision needed",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Approve temporary overtime in districts that already have qualified labor.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Sequence new hiring after route redesign to avoid absorbing avoidable cost.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "col2": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity bottlenecks",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Revenue exposure is highest in locations with the thinnest bench.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Supervisors are reallocating senior technicians to stabilize first-time fix rates.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "The queue length falls fastest when dispatch locks same-day overflow windows.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Decision needed",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Approve temporary overtime in districts that already have qualified labor.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Sequence new hiring after route redesign to avoid absorbing avoidable cost.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "col3": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Intervention levers",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Revenue exposure is highest in locations with the thinnest bench.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Supervisors are reallocating senior technicians to stabilize first-time fix rates.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "The queue length falls fastest when dispatch locks same-day overflow windows.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Decision needed",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Approve temporary overtime in districts that already have qualified labor.",
+          "type": "bullet"
+        },
+        {
+          "level": 0,
+          "text": "Sequence new hiring after route redesign to avoid absorbing avoidable cost.",
+          "type": "bullet"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    }
+  },
+  "long_heading": {
+    "col1": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand hot spots",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Orders continue to outpace available technician hours in six fast-growth corridors.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "col2": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity bottlenecks",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Travel time and uneven skill mix are preventing teams from clearing the daily queue.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "col3": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Intervention levers",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Leaders can restore service levels by rebalancing routing, hiring, and overtime rules.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Regional demand has accelerated faster than workforce capacity, forcing leaders to rebalance coverage before service levels deteriorate further",
+          "type": "heading"
+        }
+      ]
+    }
+  },
+  "narrow_safe": {
+    "col1": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand hot spots",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Keep the plan simple.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "col2": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity bottlenecks",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Keep the plan simple.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "col3": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Intervention levers",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Keep the plan simple.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Stabilize priority markets",
+          "type": "heading"
+        }
+      ]
+    }
+  },
+  "nominal": {
+    "col1": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Demand hot spots",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Orders continue to outpace available technician hours in six fast-growth corridors.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "col2": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity bottlenecks",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Travel time and uneven skill mix are preventing teams from clearing the daily queue.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "col3": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Intervention levers",
+          "type": "heading"
+        },
+        {
+          "level": 0,
+          "text": "Leaders can restore service levels by rebalancing routing, hiring, and overtime rules.",
+          "type": "paragraph"
+        }
+      ]
+    },
+    "heading": {
+      "blocks": [
+        {
+          "level": 0,
+          "text": "Capacity gaps are concentrated in a small set of service corridors",
+          "type": "heading"
+        }
+      ]
+    }
+  }
+}

--- a/scripts/generate_layout_fixtures.py
+++ b/scripts/generate_layout_fixtures.py
@@ -1,0 +1,318 @@
+"""Generate deterministic layout-case fixtures from a layout inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT = Path(__file__).resolve().parents[1]
+IMAGE_ASSET_PATHS = (
+    "examples/images/capacity-gap-map.svg",
+    "examples/images/network-coverage.svg",
+    "examples/images/service-dashboard.svg",
+)
+_SLOT_PRIORITY = {
+    "heading": 0,
+    "subheading": 10,
+    "body": 20,
+    "quote": 30,
+    "attribution": 40,
+    "image": 90,
+}
+_COLUMN_COPY = {
+    "col1": (
+        "Demand hot spots",
+        "Orders continue to outpace available technician hours in six fast-growth corridors.",
+    ),
+    "col2": (
+        "Capacity bottlenecks",
+        "Travel time and uneven skill mix are preventing teams from clearing the daily queue.",
+    ),
+    "col3": (
+        "Intervention levers",
+        "Leaders can restore service levels by rebalancing routing, hiring, and overtime rules.",
+    ),
+}
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--inventory", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    return parser.parse_args(argv)
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise ValueError(f"Inventory file not found: {path}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"Inventory file is not valid JSON: {path}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError("Inventory root must be a JSON object")
+    return payload
+
+
+def _slot_sort_key(slot_name: str) -> tuple[int, str]:
+    if slot_name in _SLOT_PRIORITY:
+        return (_SLOT_PRIORITY[slot_name], slot_name)
+    if slot_name.startswith("col") and slot_name[3:].isdigit():
+        return (50 + int(slot_name[3:]), slot_name)
+    if "_" in slot_name:
+        prefix, _, suffix = slot_name.rpartition("_")
+        if suffix.isdigit():
+            return (70, f"{prefix}:{int(suffix):06d}")
+    return (80, slot_name)
+
+
+def _text_block(block_type: str, text: str, *, level: int = 0) -> dict[str, Any]:
+    return {"type": block_type, "text": text, "level": level}
+
+
+def _text_payload(*blocks: dict[str, Any]) -> dict[str, Any]:
+    return {"blocks": list(blocks)}
+
+
+def _has_dense_body_slot(slots: list[str]) -> bool:
+    return any(slot == "body" or _is_column_slot(slot) for slot in slots)
+
+
+def _dense_body_target(slots: list[str]) -> str | None:
+    for slot in slots:
+        if slot == "body":
+            return slot
+    for slot in slots:
+        if _is_column_slot(slot):
+            return slot
+    return None
+
+
+def _is_column_slot(slot_name: str) -> bool:
+    return slot_name.startswith("col") and slot_name[3:].isdigit()
+
+
+def _image_payload(index: int) -> dict[str, Any]:
+    return {"image_path": IMAGE_ASSET_PATHS[index % len(IMAGE_ASSET_PATHS)], "image_fit": "cover"}
+
+
+def _heading_text(variant: str) -> str:
+    if variant == "long_heading":
+        return (
+            "Regional demand has accelerated faster than workforce capacity, forcing "
+            "leaders to rebalance coverage before service levels deteriorate further"
+        )
+    if variant == "narrow_safe":
+        return "Stabilize priority markets"
+    if variant == "image_missing":
+        return "Text-only fallback keeps the storyline usable when visual assets are unavailable"
+    return "Capacity gaps are concentrated in a small set of service corridors"
+
+
+def _subheading_payload(variant: str) -> dict[str, Any]:
+    if variant == "narrow_safe":
+        return _text_payload(_text_block("paragraph", "Focus on the six markets with the largest backlog."))
+    return _text_payload(
+        _text_block(
+            "paragraph",
+            "The imbalance is sharpest where demand spikes collided with slower technician hiring.",
+        )
+    )
+
+
+def _body_payload(variant: str) -> dict[str, Any]:
+    if variant == "narrow_safe":
+        return _text_payload(_text_block("paragraph", "Close the backlog before expanding coverage."))
+    if variant == "dense_body":
+        return _text_payload(
+            _text_block("heading", "Implications"),
+            _text_block("bullet", "Backlog exceeds the ten-day threshold in six priority metros."),
+            _text_block("bullet", "Travel time inflation is eroding technician utilization by roughly one shift per week."),
+            _text_block("bullet", "Attrition remains elevated where supervisors manage both dispatch and field coaching."),
+            _text_block("heading", "Actions underway"),
+            _text_block("bullet", "Leadership is staging targeted hiring against the highest-margin territories first."),
+            _text_block("bullet", "Routing rules are being reset to reduce cross-district spillover."),
+            _text_block("bullet", "Weekly performance reviews now compare service-level recovery against hiring conversion."),
+        )
+    return _text_payload(
+        _text_block(
+            "paragraph",
+            "Demand grew 14% year on year while field capacity expanded only 6%, leaving recurring coverage gaps in select metros.",
+        ),
+        _text_block("bullet", "Eight priority markets account for most of the open service backlog."),
+        _text_block("bullet", "Utilization improves quickly when routing is reset at the district level."),
+    )
+
+
+def _column_payload(slot_name: str, variant: str) -> dict[str, Any]:
+    heading_text, paragraph_text = _COLUMN_COPY.get(
+        slot_name,
+        (
+            f"{slot_name.replace('_', ' ').title()} focus",
+            "The workstream has a clear owner, measurable backlog, and a near-term operating target.",
+        ),
+    )
+    if variant == "narrow_safe":
+        return _text_payload(_text_block("heading", heading_text), _text_block("paragraph", "Keep the plan simple."))
+    if variant == "dense_body":
+        return _text_payload(
+            _text_block("heading", heading_text),
+            _text_block("bullet", "Revenue exposure is highest in locations with the thinnest bench."),
+            _text_block("bullet", "Supervisors are reallocating senior technicians to stabilize first-time fix rates."),
+            _text_block("bullet", "The queue length falls fastest when dispatch locks same-day overflow windows."),
+            _text_block("heading", "Decision needed"),
+            _text_block("bullet", "Approve temporary overtime in districts that already have qualified labor."),
+            _text_block("bullet", "Sequence new hiring after route redesign to avoid absorbing avoidable cost."),
+        )
+    return _text_payload(_text_block("heading", heading_text), _text_block("paragraph", paragraph_text))
+
+
+def _quote_payload(variant: str) -> dict[str, Any]:
+    if variant == "narrow_safe":
+        return _text_payload(_text_block("paragraph", "Capacity followed the old footprint, not the new demand map."))
+    return _text_payload(
+        _text_block(
+            "paragraph",
+            "We do not have a national staffing issue; we have a regional planning issue that looks national in aggregate.",
+        )
+    )
+
+
+def _attribution_payload() -> dict[str, Any]:
+    return _text_payload(_text_block("paragraph", "Chief Operating Officer"))
+
+
+def _default_payload(slot_name: str, variant: str) -> dict[str, Any]:
+    if variant == "narrow_safe":
+        return _text_payload(_text_block("paragraph", f"{slot_name.replace('_', ' ').title()} stays concise."))
+    return _text_payload(
+        _text_block(
+            "paragraph",
+            f"{slot_name.replace('_', ' ').title()} reinforces the operating case with a short, concrete point.",
+        )
+    )
+
+
+def _slot_payload(slot_name: str, variant: str, *, dense_target: str | None) -> dict[str, Any] | None:
+    if slot_name == "image":
+        if variant == "image_missing":
+            return None
+        image_index = 1 if variant == "image_present" else 0
+        return _image_payload(image_index)
+    if slot_name == "heading":
+        return _text_payload(_text_block("heading", _heading_text(variant)))
+    if slot_name == "subheading":
+        return _subheading_payload(variant)
+    if slot_name == "body":
+        body_variant = "dense_body" if dense_target == slot_name and variant == "dense_body" else variant
+        return _body_payload(body_variant)
+    if _is_column_slot(slot_name):
+        column_variant = "dense_body" if dense_target == slot_name and variant == "dense_body" else variant
+        return _column_payload(slot_name, column_variant)
+    if slot_name == "quote":
+        return _quote_payload(variant)
+    if slot_name == "attribution":
+        return _attribution_payload()
+    return _default_payload(slot_name, variant)
+
+
+def _build_variant(slots: list[str], variant: str) -> dict[str, Any]:
+    dense_target = _dense_body_target(slots) if variant == "dense_body" else None
+    payload: dict[str, Any] = {}
+    for slot_name in slots:
+        slot_payload = _slot_payload(slot_name, variant, dense_target=dense_target)
+        if slot_payload is not None:
+            payload[slot_name] = slot_payload
+    return payload
+
+
+def _collect_slot_structures(inventory: dict[str, Any]) -> dict[str, list[str]]:
+    layouts = inventory.get("layouts")
+    if not isinstance(layouts, list):
+        raise ValueError("Inventory field 'layouts' must be a list")
+
+    structures: dict[str, set[str]] = {}
+    for layout in layouts:
+        if not isinstance(layout, dict):
+            raise ValueError("Inventory layouts must be objects")
+        if not bool(layout.get("testable", False)):
+            continue
+
+        slot_structure = layout.get("slot_structure")
+        if not isinstance(slot_structure, str) or not slot_structure.strip():
+            raise ValueError("Testable layouts must include a non-empty 'slot_structure'")
+        fillable_slots = layout.get("fillable_slots")
+        if not isinstance(fillable_slots, list) or not all(isinstance(slot, str) for slot in fillable_slots):
+            raise ValueError(f"Layout '{layout.get('slug', '<unknown>')}' fillable_slots must be a list of strings")
+
+        structures.setdefault(slot_structure, set()).update(fillable_slots)
+
+    if not structures:
+        raise ValueError("Inventory does not contain any testable layouts")
+
+    return {key: sorted(values, key=_slot_sort_key) for key, values in sorted(structures.items())}
+
+
+def build_fixture_payloads(inventory: dict[str, Any]) -> dict[str, dict[str, dict[str, Any]]]:
+    for asset_path in IMAGE_ASSET_PATHS:
+        if not (ROOT / asset_path).is_file():
+            raise ValueError(f"Image fixture asset not found: {asset_path}")
+
+    structures = _collect_slot_structures(inventory)
+    payloads: dict[str, dict[str, dict[str, Any]]] = {}
+    for slot_structure, slots in structures.items():
+        variants = {
+            "nominal": _build_variant(slots, "nominal"),
+            "narrow_safe": _build_variant(slots, "narrow_safe"),
+        }
+        if "heading" in slots:
+            variants["long_heading"] = _build_variant(slots, "long_heading")
+        if _has_dense_body_slot(slots):
+            variants["dense_body"] = _build_variant(slots, "dense_body")
+        if "image" in slots:
+            variants["image_present"] = _build_variant(slots, "image_present")
+            variants["image_missing"] = _build_variant(slots, "image_missing")
+        payloads[slot_structure] = variants
+    return payloads
+
+
+def write_fixture_payloads(payloads: dict[str, dict[str, dict[str, Any]]], output_dir: Path) -> list[Path]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    written_paths: list[Path] = []
+    for slot_structure, payload in payloads.items():
+        path = output_dir / f"{slot_structure}.json"
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        written_paths.append(path)
+    return written_paths
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        inventory = _load_json(args.inventory)
+        payloads = build_fixture_payloads(inventory)
+        written_paths = write_fixture_payloads(payloads, args.output)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    json.dump(
+        {
+            "inventory": str(args.inventory),
+            "output_dir": str(args.output),
+            "slot_structure_count": len(written_paths),
+            "written_files": [path.name for path in written_paths],
+        },
+        sys.stdout,
+        indent=2,
+        sort_keys=True,
+    )
+    sys.stdout.write("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_generate_layout_fixtures.py
+++ b/tests/test_generate_layout_fixtures.py
@@ -1,0 +1,164 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from agent_slides.model.types import NodeContent
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "generate_layout_fixtures.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("generate_layout_fixtures", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _write_inventory(path: Path) -> None:
+    path.write_text(
+        json.dumps(
+            {
+                "layouts": [
+                    {
+                        "slug": "title_only",
+                        "testable": True,
+                        "slot_structure": "heading_only",
+                        "fillable_slots": ["heading", "subheading"],
+                    },
+                    {
+                        "slug": "body_text",
+                        "testable": True,
+                        "slot_structure": "heading_body",
+                        "fillable_slots": ["heading", "body"],
+                    },
+                    {
+                        "slug": "visual_story",
+                        "testable": True,
+                        "slot_structure": "heading_image",
+                        "fillable_slots": ["heading", "image"],
+                    },
+                    {
+                        "slug": "mixed_story",
+                        "testable": True,
+                        "slot_structure": "heading_body_image",
+                        "fillable_slots": ["heading", "body", "image"],
+                    },
+                    {
+                        "slug": "three_up",
+                        "testable": True,
+                        "slot_structure": "multi_slot",
+                        "fillable_slots": ["heading", "col1", "col2", "col3"],
+                    },
+                    {
+                        "slug": "blankish",
+                        "testable": False,
+                        "slot_structure": "blank",
+                        "fillable_slots": [],
+                    },
+                ]
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+
+def _run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _validate_text_payloads(payload: dict[str, object]) -> None:
+    for slot_name, slot_payload in payload.items():
+        assert isinstance(slot_name, str)
+        assert isinstance(slot_payload, dict)
+        if "image_path" in slot_payload:
+            image_path = ROOT / str(slot_payload["image_path"])
+            assert image_path.is_file()
+            continue
+        validated = NodeContent.model_validate(slot_payload)
+        assert validated.blocks
+
+
+def test_generate_layout_fixtures_cli_writes_expected_fixture_files(tmp_path: Path) -> None:
+    inventory_path = tmp_path / "layout-inventory.json"
+    output_dir = tmp_path / "layout_cases"
+    _write_inventory(inventory_path)
+
+    result = _run_script("--inventory", str(inventory_path), "--output", str(output_dir))
+
+    assert result.returncode == 0, result.stderr
+    summary = json.loads(result.stdout)
+    assert summary["slot_structure_count"] == 5
+    assert summary["written_files"] == [
+        "heading_body.json",
+        "heading_body_image.json",
+        "heading_image.json",
+        "heading_only.json",
+        "multi_slot.json",
+    ]
+
+    heading_only = json.loads((output_dir / "heading_only.json").read_text(encoding="utf-8"))
+    assert set(heading_only) == {"long_heading", "narrow_safe", "nominal"}
+    assert len(heading_only["long_heading"]["heading"]["blocks"][0]["text"]) > 80
+
+    heading_body = json.loads((output_dir / "heading_body.json").read_text(encoding="utf-8"))
+    assert "dense_body" in heading_body
+    assert len(heading_body["dense_body"]["body"]["blocks"]) >= 6
+
+    heading_image = json.loads((output_dir / "heading_image.json").read_text(encoding="utf-8"))
+    assert {"image_present", "image_missing", "long_heading", "narrow_safe", "nominal"} == set(heading_image)
+    assert "image" in heading_image["image_present"]
+    assert "image" not in heading_image["image_missing"]
+
+    for fixture_path in sorted(output_dir.glob("*.json")):
+        payload = json.loads(fixture_path.read_text(encoding="utf-8"))
+        for variant_payload in payload.values():
+            assert isinstance(variant_payload, dict)
+            _validate_text_payloads(variant_payload)
+
+
+def test_generate_layout_fixtures_is_deterministic(tmp_path: Path) -> None:
+    inventory_path = tmp_path / "layout-inventory.json"
+    first_output_dir = tmp_path / "first"
+    second_output_dir = tmp_path / "second"
+    _write_inventory(inventory_path)
+
+    first = _run_script("--inventory", str(inventory_path), "--output", str(first_output_dir))
+    second = _run_script("--inventory", str(inventory_path), "--output", str(second_output_dir))
+
+    assert first.returncode == 0, first.stderr
+    assert second.returncode == 0, second.stderr
+
+    first_payloads = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in sorted(first_output_dir.glob("*.json"))
+    }
+    second_payloads = {
+        path.name: path.read_text(encoding="utf-8")
+        for path in sorted(second_output_dir.glob("*.json"))
+    }
+    assert first_payloads == second_payloads
+
+
+def test_build_fixture_payloads_rejects_inventory_without_testable_layouts(tmp_path: Path) -> None:
+    module = _load_script_module()
+    inventory_path = tmp_path / "layout-inventory.json"
+    inventory_path.write_text(json.dumps({"layouts": [{"slug": "blank", "testable": False, "slot_structure": "blank"}]}), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="does not contain any testable layouts"):
+        module.build_fixture_payloads(json.loads(inventory_path.read_text(encoding="utf-8")))


### PR DESCRIPTION
## Summary
- add `scripts/generate_layout_fixtures.py` to build deterministic slot-structure fixture sets from a layout inventory
- check in generated `fixtures/layout_cases/*.json` files and real SVG image assets under `examples/images/`
- add focused tests covering CLI output, payload validity, and deterministic generation

Closes #230