### PR TITLE
Integrate review quality into demo scoring

### DIFF
--- a/program-demo.md
+++ b/program-demo.md
@@ -58,14 +58,16 @@ Deterministic metrics (from `scripts/demo_research.py`):
 - `placeholder_fill`: % of slots with content (weight 20)
 - `layout_variety`: distinct layouts / minimum required (weight 10)
 - `slide_count_match`: actual slides within expected range (weight 10)
+- `review_quality`: visual review checklist pass ratio, computed as `passed / total` from `review/report.json` (weight 20 when review is available)
 
-Composite: weighted average, 0-100 scale.
+Composite: weighted average, 0-100 scale. If LibreOffice-backed review is unavailable, set `review_available: false` for that benchmark and exclude `review_quality` from the composite instead of scoring it as 0.
 
 ## Accept/reject rule
 
-- **Accept** if composite >= previous best AND no regression on any individual metric > 10 points
-- **Reject** if composite < previous best OR any metric regresses > 10 points
-- **Escalate to human** if composite improves but a metric regresses > 5 points (trade-off decision)
+- **Accept** if mean composite is at least the previous best and every benchmark's `review_quality` stays within 0.05 of the previous best benchmark.
+- **Reject** if mean composite regresses versus the previous best run.
+- **Reject** if any benchmark's `review_quality` regresses by more than 0.05 versus the same benchmark in the previous best run, even when composite improves.
+- **Flag** benchmarks with `review_available: false` as review-unavailable runs. They may stay in the run summary, but they do not contribute a 0-valued review score to the composite and should not be treated as visual-proof wins.
 
 ## Current hypothesis
 

--- a/scripts/demo_research.py
+++ b/scripts/demo_research.py
@@ -20,10 +20,12 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+from typing import Any
 
 ROOT = Path(__file__).resolve().parent.parent
 BENCHMARKS_DIR = ROOT / "benchmarks"
 RUNS_DIR = ROOT / "runs"
+REVIEW_REGRESSION_THRESHOLD = 0.05
 
 # Deterministic score weights
 WEIGHTS = {
@@ -34,21 +36,191 @@ WEIGHTS = {
     "layout_variety": 10,       # distinct layouts used / expected minimum
     "slide_count_match": 10,    # actual vs expected slide count
     "build_success": 10,        # PPTX builds without error
+    "review_quality": 20,       # visual review passed/total ratio when available
 }
 
 
-def run_cli(*args: str, cwd: Path | None = None) -> dict | None:
-    """Run an agent-slides CLI command and return parsed JSON or None on failure."""
+def _parse_json(text: str) -> dict[str, Any] | None:
+    if not text.strip():
+        return None
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def invoke_cli(*args: str, cwd: Path | None = None) -> tuple[int, dict[str, Any] | None, dict[str, Any] | None]:
+    """Run an agent-slides CLI command and return the exit code plus parsed stdout/stderr JSON."""
     cmd = ["uv", "run", "--project", str(ROOT), "agent-slides", *args]
     result = subprocess.run(cmd, capture_output=True, text=True, cwd=cwd or ROOT)
+    stdout_payload = _parse_json(result.stdout)
+    stderr_payload = _parse_json(result.stderr)
     if result.returncode != 0:
         print(f"  FAIL: {' '.join(args)}", file=sys.stderr)
         print(f"  stderr: {result.stderr[:500]}", file=sys.stderr)
+    return result.returncode, stdout_payload, stderr_payload
+
+
+def run_cli(*args: str, cwd: Path | None = None) -> dict[str, Any] | None:
+    """Run an agent-slides CLI command and return parsed stdout JSON or None on failure."""
+    returncode, stdout_payload, _ = invoke_cli(*args, cwd=cwd)
+    if returncode != 0:
         return None
-    try:
-        return json.loads(result.stdout)
-    except json.JSONDecodeError:
+    return stdout_payload
+
+
+def base_scores(*, error: str | None = None) -> dict[str, Any]:
+    scores: dict[str, Any] = {
+        "build_success": 0.0,
+        "validate_clean": 0.0,
+        "validate_warnings": -1,
+        "slide_count_match": 0.0,
+        "slide_count": 0,
+        "layout_variety": 0.0,
+        "layouts_used": [],
+        "overflow_count": 0,
+        "no_overflow": 0.0,
+        "unbound_count": 0,
+        "no_unbound": 0.0,
+        "placeholder_fill": 0.0,
+        "filled_slots": 0,
+        "total_slots": 0,
+        "review_grade": "N/A",
+        "review_slides": 0,
+        "review_quality": 0.0,
+        "review_passed": 0,
+        "review_total": 0,
+        "review_available": False,
+    }
+    if error is not None:
+        scores["error"] = error
+    return scores
+
+
+def compute_composite(scores: dict[str, Any]) -> float:
+    composite = 0.0
+    total_weight = 0
+    for metric, weight in WEIGHTS.items():
+        if metric == "review_quality" and not scores.get("review_available", False):
+            continue
+        value = scores.get(metric, 0.0)
+        if isinstance(value, (int, float)):
+            composite += value * weight
+            total_weight += weight
+    return round(composite / total_weight * 100, 1) if total_weight > 0 else 0.0
+
+
+def load_json(path: Path) -> dict[str, Any] | None:
+    if not path.exists():
         return None
+    return _parse_json(path.read_text(encoding="utf-8"))
+
+
+def load_review_metrics(report_json_path: Path) -> dict[str, Any]:
+    report = load_json(report_json_path) or {}
+    active = report.get("active", {})
+    overall = active.get("overall", {})
+    passed = int(overall.get("passed", 0) or 0)
+    total = int(overall.get("total", 0) or 0)
+    return {
+        "review_available": True,
+        "review_passed": passed,
+        "review_total": total,
+        "review_quality": round(passed / total, 4) if total > 0 else 0.0,
+        "review_grade": overall.get("grade", active.get("grade", "N/A")),
+    }
+
+
+def previous_best_summary(*, current_run_id: str) -> dict[str, Any] | None:
+    candidates: list[dict[str, Any]] = []
+    for summary_path in sorted(RUNS_DIR.glob("*/summary.json")):
+        if summary_path.parent.name == current_run_id:
+            continue
+        summary = load_json(summary_path)
+        if summary is None:
+            continue
+        if summary.get("decision") == "reject":
+            continue
+        if isinstance(summary.get("mean_composite"), (int, float)):
+            candidates.append(summary)
+    if not candidates:
+        return None
+    return max(candidates, key=lambda item: float(item.get("mean_composite", 0.0)))
+
+
+def evaluate_reject_reasons(
+    results: list[dict[str, Any]],
+    *,
+    current_mean_composite: float,
+    baseline_summary: dict[str, Any] | None,
+) -> list[str]:
+    if baseline_summary is None:
+        return []
+
+    reject_reasons: list[str] = []
+    baseline_mean = float(baseline_summary.get("mean_composite", 0.0))
+    if current_mean_composite < baseline_mean:
+        reject_reasons.append(
+            f"composite regressed from {baseline_mean:.1f} to {current_mean_composite:.1f}"
+        )
+
+    baseline_scores = {
+        benchmark.get("benchmark"): benchmark.get("scores", {})
+        for benchmark in baseline_summary.get("benchmarks", [])
+        if isinstance(benchmark, dict)
+    }
+
+    for result in results:
+        benchmark_name = result.get("benchmark")
+        if not isinstance(benchmark_name, str):
+            continue
+        current_scores = result.get("scores", {})
+        if not isinstance(current_scores, dict):
+            continue
+        baseline_benchmark_scores = baseline_scores.get(benchmark_name)
+        if not isinstance(baseline_benchmark_scores, dict):
+            continue
+        if not current_scores.get("review_available") or not baseline_benchmark_scores.get("review_available"):
+            continue
+
+        current_quality = float(current_scores.get("review_quality", 0.0))
+        baseline_quality = float(baseline_benchmark_scores.get("review_quality", 0.0))
+        if baseline_quality - current_quality > REVIEW_REGRESSION_THRESHOLD:
+            reject_reasons.append(
+                f"{benchmark_name}: review_quality regressed from {baseline_quality:.3f} to {current_quality:.3f}"
+            )
+
+    return reject_reasons
+
+
+def build_summary(*, run_id: str, results: list[dict[str, Any]]) -> dict[str, Any]:
+    composites = [r["scores"]["composite"] for r in results if "composite" in r["scores"]]
+    mean_composite = round(sum(composites) / len(composites), 1) if composites else 0.0
+    baseline_summary = previous_best_summary(current_run_id=run_id)
+    reject_reasons = evaluate_reject_reasons(
+        results,
+        current_mean_composite=mean_composite,
+        baseline_summary=baseline_summary,
+    )
+    review_unavailable = [
+        result["benchmark"]
+        for result in results
+        if not result.get("scores", {}).get("review_available", False)
+    ]
+    summary: dict[str, Any] = {
+        "run_id": run_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "benchmarks": results,
+        "mean_composite": mean_composite,
+        "decision": "reject" if reject_reasons else "accept",
+        "reject_reasons": reject_reasons,
+        "review_unavailable_benchmarks": review_unavailable,
+    }
+    if baseline_summary is not None:
+        summary["previous_best_run_id"] = baseline_summary.get("run_id")
+        summary["previous_best_mean_composite"] = baseline_summary.get("mean_composite")
+    return summary
 
 
 def parse_brief(brief_path: Path) -> dict:
@@ -100,7 +272,7 @@ def parse_brief(brief_path: Path) -> dict:
 
 def score_deck(deck_path: Path, brief: dict, run_dir: Path) -> dict:
     """Score a built deck against deterministic metrics."""
-    scores: dict = {}
+    scores = base_scores()
 
     # Run commands from the deck's directory so relative manifest/template paths resolve
     deck_cwd = deck_path.parent
@@ -150,7 +322,6 @@ def score_deck(deck_path: Path, brief: dict, run_dir: Path) -> dict:
         # Overflow and unbound analysis
         overflow_count = 0
         unbound_count = 0
-        total_text_nodes = 0
         filled_slots = 0
         total_slots = 0
         for slide in slides:
@@ -160,7 +331,6 @@ def score_deck(deck_path: Path, brief: dict, run_dir: Path) -> dict:
                 node_id = node.get("node_id", "")
                 comp = computed.get(node_id, {})
                 if node.get("type") == "text":
-                    total_text_nodes += 1
                     if comp.get("text_overflow"):
                         overflow_count += 1
                 if node.get("slot_binding"):
@@ -196,22 +366,18 @@ def score_deck(deck_path: Path, brief: dict, run_dir: Path) -> dict:
 
     # 4. Review (render PNGs)
     review_dir = run_dir / "review"
-    review_result = run_cli("review", str(deck_path), "-o", str(review_dir), cwd=deck_cwd)
-    if review_result and review_result.get("ok"):
-        scores["review_grade"] = review_result["data"].get("overall_grade", "F")
-        scores["review_slides"] = review_result["data"].get("slides", 0)
-    else:
-        scores["review_grade"] = "N/A"
+    review_exit_code, review_result, review_error = invoke_cli("review", str(deck_path), "-o", str(review_dir), cwd=deck_cwd)
+    if review_exit_code == 0 and review_result and review_result.get("ok"):
+        review_data = review_result.get("data", {})
+        scores["review_slides"] = review_data.get("slides", 0)
+        scores["review_grade"] = review_data.get("overall_grade", "N/A")
+        report_json_path = review_data.get("report_json_path")
+        if isinstance(report_json_path, str):
+            scores.update(load_review_metrics(Path(report_json_path)))
+    elif review_error:
+        scores["review_error"] = review_error.get("error", {}).get("message", "review failed")
 
-    # 5. Composite score
-    composite = 0.0
-    total_weight = 0
-    for metric, weight in WEIGHTS.items():
-        value = scores.get(metric, 0.0)
-        if isinstance(value, (int, float)):
-            composite += value * weight
-            total_weight += weight
-    scores["composite"] = round(composite / total_weight * 100, 1) if total_weight > 0 else 0.0
+    scores["composite"] = compute_composite(scores)
 
     return scores
 
@@ -250,7 +416,8 @@ def run_benchmark(brief_path: Path, run_dir: Path, manifest_path: Path | None = 
         scores = score_deck(deck_path, brief, bench_dir)
     else:
         print(f"  No deck.json found at {deck_path}, skipping.")
-        scores = {"composite": 0.0, "error": "no deck.json"}
+        scores = base_scores(error="no deck.json")
+        scores["composite"] = compute_composite(scores)
 
     # Save scores
     scores_path = bench_dir / "scores.json"
@@ -290,13 +457,7 @@ def main():
         results.append(result)
 
     # Aggregate summary
-    composites = [r["scores"]["composite"] for r in results if "composite" in r["scores"]]
-    summary = {
-        "run_id": run_id,
-        "timestamp": datetime.now(timezone.utc).isoformat(),
-        "benchmarks": results,
-        "mean_composite": round(sum(composites) / len(composites), 1) if composites else 0.0,
-    }
+    summary = build_summary(run_id=run_id, results=results)
 
     summary_path = run_dir / "summary.json"
     summary_path.write_text(json.dumps(summary, indent=2))

--- a/skills/demo-cycle/SKILL.md
+++ b/skills/demo-cycle/SKILL.md
@@ -69,18 +69,18 @@ This scores all benchmarks and writes `runs/<run_id>/summary.json`.
 1. Read the new `summary.json`.
 2. Compare against the previous best run (if any).
 3. Apply the accept/reject rule from `program-demo.md`:
-   - **Accept**: composite >= previous best AND no individual metric regresses > 10 points
-   - **Reject**: composite < previous best OR any metric regresses > 10 points
-   - **Escalate**: composite improves but a metric regresses > 5 points
+   - **Accept**: `summary.json` has no `reject_reasons`
+   - **Reject**: mean composite regresses versus the previous best run
+   - **Reject**: any benchmark `review_quality` regresses by more than 0.05 versus the same benchmark in the previous best run, even if composite improves
+   - **Check**: if a benchmark has `review_available: false`, treat it as review-unavailable and confirm the scorer excluded `review_quality` from composite instead of scoring it as 0
 4. Write a short summary to `runs/<run_id>/decision.md` with:
    - What was changed
    - Score delta
-   - Decision (accept/reject/escalate)
+   - Decision (accept/reject)
    - What to try next
 
 5. If **rejected**: revert the code changes (`git checkout -- <files>`). The run artifacts stay for analysis.
 6. If **accepted**: keep the changes (do not commit — the human will review and commit).
-7. If **escalate**: keep the changes but flag clearly in decision.md.
 
 ## Constraints
 

--- a/tests/test_demo_research.py
+++ b/tests/test_demo_research.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from scripts import demo_research
+
+
+def _brief() -> dict[str, int]:
+    return {"min_slides": 1, "max_slides": 1, "min_layouts": 1}
+
+
+def _info_payload() -> dict[str, object]:
+    return {
+        "slides": [
+            {
+                "layout": "title",
+                "computed": {"n-1": {}},
+                "nodes": [
+                    {
+                        "node_id": "n-1",
+                        "slot_binding": "heading",
+                        "type": "text",
+                        "content": {"blocks": [{"text": "Hello"}]},
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_score_deck_records_review_quality_from_report_ratio(tmp_path: Path, monkeypatch) -> None:
+    deck_path = tmp_path / "deck.json"
+    deck_path.write_text("{}", encoding="utf-8")
+    report_json_path = tmp_path / "review-report.json"
+    report_json_path.write_text(
+        json.dumps({"active": {"overall": {"grade": "B", "passed": 8, "total": 10}}}),
+        encoding="utf-8",
+    )
+
+    def fake_run_cli(*args: str, cwd: Path | None = None) -> dict[str, object] | None:
+        if args[0] == "build":
+            Path(args[3]).write_bytes(b"pptx")
+            return {"ok": True}
+        if args[0] == "validate":
+            return {"ok": True, "data": {"warnings": []}}
+        if args[0] == "info":
+            return _info_payload()
+        raise AssertionError(f"unexpected command: {args}")
+
+    def fake_invoke_cli(
+        *args: str,
+        cwd: Path | None = None,
+    ) -> tuple[int, dict[str, object] | None, dict[str, object] | None]:
+        assert args[0] == "review"
+        return (
+            0,
+            {
+                "ok": True,
+                "data": {
+                    "overall_grade": "B",
+                    "slides": 1,
+                    "report_json_path": str(report_json_path),
+                },
+            },
+            None,
+        )
+
+    monkeypatch.setattr(demo_research, "run_cli", fake_run_cli)
+    monkeypatch.setattr(demo_research, "invoke_cli", fake_invoke_cli)
+
+    scores = demo_research.score_deck(deck_path, _brief(), tmp_path)
+
+    assert scores["review_available"] is True
+    assert scores["review_passed"] == 8
+    assert scores["review_total"] == 10
+    assert scores["review_quality"] == 0.8
+    assert scores["composite"] == 96.7
+
+
+def test_score_deck_excludes_unavailable_review_from_composite(tmp_path: Path, monkeypatch) -> None:
+    deck_path = tmp_path / "deck.json"
+    deck_path.write_text("{}", encoding="utf-8")
+
+    def fake_run_cli(*args: str, cwd: Path | None = None) -> dict[str, object] | None:
+        if args[0] == "build":
+            Path(args[3]).write_bytes(b"pptx")
+            return {"ok": True}
+        if args[0] == "validate":
+            return {"ok": True, "data": {"warnings": []}}
+        if args[0] == "info":
+            return _info_payload()
+        raise AssertionError(f"unexpected command: {args}")
+
+    def fake_invoke_cli(
+        *args: str,
+        cwd: Path | None = None,
+    ) -> tuple[int, dict[str, object] | None, dict[str, object] | None]:
+        assert args[0] == "review"
+        return (
+            1,
+            None,
+            {"error": {"message": "Visual review requires 'soffice' to be installed and available on PATH."}},
+        )
+
+    monkeypatch.setattr(demo_research, "run_cli", fake_run_cli)
+    monkeypatch.setattr(demo_research, "invoke_cli", fake_invoke_cli)
+
+    scores = demo_research.score_deck(deck_path, _brief(), tmp_path)
+
+    assert scores["review_available"] is False
+    assert scores["review_quality"] == 0.0
+    assert scores["review_passed"] == 0
+    assert scores["review_total"] == 0
+    assert "soffice" in scores["review_error"]
+    assert scores["composite"] == 100.0
+
+
+def test_run_benchmark_without_deck_still_writes_review_fields(tmp_path: Path) -> None:
+    brief_path = tmp_path / "minimal.md"
+    brief_path.write_text(
+        "# Minimal\n\n## Expected slide count\n1\n\n## Layout variety\nAt least 1 distinct layout\n",
+        encoding="utf-8",
+    )
+
+    result = demo_research.run_benchmark(brief_path, tmp_path / "runs")
+
+    scores = result["scores"]
+    assert scores["review_available"] is False
+    assert scores["review_quality"] == 0.0
+    assert scores["review_passed"] == 0
+    assert scores["review_total"] == 0
+
+
+def test_build_summary_rejects_review_regressions_even_when_composite_improves(monkeypatch) -> None:
+    previous = {
+        "run_id": "baseline",
+        "mean_composite": 80.0,
+        "benchmarks": [
+            {"benchmark": "alpha", "scores": {"composite": 80.0, "review_available": True, "review_quality": 0.92}},
+            {"benchmark": "beta", "scores": {"composite": 78.0, "review_available": True, "review_quality": 0.88}},
+        ],
+    }
+    results = [
+        {"benchmark": "alpha", "scores": {"composite": 83.0, "review_available": True, "review_quality": 0.84}},
+        {"benchmark": "beta", "scores": {"composite": 82.0, "review_available": True, "review_quality": 0.8}},
+    ]
+
+    monkeypatch.setattr(demo_research, "previous_best_summary", lambda current_run_id: previous)
+
+    summary = demo_research.build_summary(run_id="candidate", results=results)
+
+    assert summary["decision"] == "reject"
+    assert len(summary["reject_reasons"]) == 2
+    assert "alpha: review_quality regressed" in summary["reject_reasons"][0]
+    assert "beta: review_quality regressed" in summary["reject_reasons"][1]
+
+
+def test_build_summary_rejects_composite_regression_even_when_review_improves(monkeypatch) -> None:
+    previous = {
+        "run_id": "baseline",
+        "mean_composite": 81.0,
+        "benchmarks": [
+            {"benchmark": "alpha", "scores": {"composite": 81.0, "review_available": True, "review_quality": 0.7}}
+        ],
+    }
+    results = [
+        {"benchmark": "alpha", "scores": {"composite": 79.0, "review_available": True, "review_quality": 0.95}}
+    ]
+
+    monkeypatch.setattr(demo_research, "previous_best_summary", lambda current_run_id: previous)
+
+    summary = demo_research.build_summary(run_id="candidate", results=results)
+
+    assert summary["decision"] == "reject"
+    assert summary["reject_reasons"] == ["composite regressed from 81.0 to 79.0"]


### PR DESCRIPTION
## Summary
- parse demo review artifacts into explicit `review_quality`, `review_passed`, `review_total`, and `review_available` benchmark fields
- gate run acceptance on mean composite regression and per-benchmark `review_quality` regression, and emit structured `reject_reasons`
- document the explicit review-quality rule and add scorer tests for unavailable-review and regression cases

Closes #237