### PR TITLE
Add per-layout coverage regression gate

### DIFF
--- a/program-demo.md
+++ b/program-demo.md
@@ -67,6 +67,7 @@ Composite: weighted average, 0-100 scale. If LibreOffice-backed review is unavai
 - **Accept** if mean composite is at least the previous best and every benchmark's `review_quality` stays within 0.05 of the previous best benchmark.
 - **Reject** if mean composite regresses versus the previous best run.
 - **Reject** if any benchmark's `review_quality` regresses by more than 0.05 versus the same benchmark in the previous best run, even when composite improves.
+- **Reject** if the previous best run has `coverage.json` and any layout slug that previously had `variants_passed > 0` now has `variants_passed == 0` in the current run's `coverage.json`. Include the regressed slugs in the reject reason.
 - **Flag** benchmarks with `review_available: false` as review-unavailable runs. They may stay in the run summary, but they do not contribute a 0-valued review score to the composite and should not be treated as visual-proof wins.
 
 ## Current hypothesis

--- a/scripts/compare_coverage.py
+++ b/scripts/compare_coverage.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Compare per-layout coverage between two coverage.json runs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+def _load_coverage(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Coverage payload must be a JSON object: {path}")
+    return payload
+
+
+def _layouts_by_slug(coverage: dict[str, Any]) -> dict[str, dict[str, Any]]:
+    layouts = coverage.get("layouts", [])
+    if not isinstance(layouts, list):
+        raise ValueError("Coverage payload must include a list-valued 'layouts' field")
+
+    by_slug: dict[str, dict[str, Any]] = {}
+    for layout in layouts:
+        if not isinstance(layout, dict):
+            raise ValueError("Coverage layouts must be JSON objects")
+        slug = layout.get("slug")
+        if not isinstance(slug, str) or not slug:
+            raise ValueError("Coverage layouts must include a non-empty 'slug'")
+        by_slug[slug] = layout
+    return by_slug
+
+
+def _variants_passed(layout: dict[str, Any]) -> int:
+    value = layout.get("variants_passed", 0)
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise ValueError("Coverage layouts must include integer 'variants_passed' values")
+    return value
+
+
+def compare_coverage_payloads(before: dict[str, Any], after: dict[str, Any]) -> dict[str, Any]:
+    before_template = before.get("template")
+    after_template = after.get("template")
+    if isinstance(before_template, str) and isinstance(after_template, str) and before_template != after_template:
+        raise ValueError(
+            f"Coverage templates do not match: before={before_template!r}, after={after_template!r}"
+        )
+
+    before_layouts = _layouts_by_slug(before)
+    after_layouts = _layouts_by_slug(after)
+
+    regressions: list[dict[str, int | str]] = []
+    improvements: list[dict[str, int | str]] = []
+    unchanged: list[dict[str, int | str]] = []
+    new_layouts: list[dict[str, int | str]] = []
+
+    for slug in sorted(after_layouts):
+        after_passed = _variants_passed(after_layouts[slug])
+        before_layout = before_layouts.get(slug)
+        if before_layout is None:
+            new_layouts.append({"slug": slug, "before_passed": 0, "after_passed": after_passed})
+            continue
+
+        before_passed = _variants_passed(before_layout)
+        entry = {"slug": slug, "before_passed": before_passed, "after_passed": after_passed}
+        if before_passed > 0 and after_passed == 0:
+            regressions.append(entry)
+        elif before_passed == 0 and after_passed > 0:
+            improvements.append(entry)
+        else:
+            unchanged.append(entry)
+
+    for slug in sorted(set(before_layouts) - set(after_layouts)):
+        before_passed = _variants_passed(before_layouts[slug])
+        entry = {"slug": slug, "before_passed": before_passed, "after_passed": 0}
+        if before_passed > 0:
+            regressions.append(entry)
+        else:
+            unchanged.append(entry)
+
+    def _sort_entries(entries: list[dict[str, int | str]]) -> list[dict[str, int | str]]:
+        return sorted(entries, key=lambda entry: str(entry["slug"]))
+
+    return {
+        "template": after_template if isinstance(after_template, str) else before_template,
+        "regressions": _sort_entries(regressions),
+        "improvements": _sort_entries(improvements),
+        "unchanged": _sort_entries(unchanged),
+        "new_layouts": _sort_entries(new_layouts),
+    }
+
+
+def compare_coverage_files(*, before_path: Path, after_path: Path) -> dict[str, Any]:
+    return compare_coverage_payloads(_load_coverage(before_path), _load_coverage(after_path))
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Compare per-layout coverage between two runs")
+    parser.add_argument("--before", required=True, type=Path, help="Previous best coverage.json")
+    parser.add_argument("--after", required=True, type=Path, help="Current run coverage.json")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv)
+    try:
+        diff = compare_coverage_files(before_path=args.before, after_path=args.after)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+
+    json.dump(diff, sys.stdout, indent=2, sort_keys=True)
+    sys.stdout.write("\n")
+    return 1 if diff["regressions"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/demo_research.py
+++ b/scripts/demo_research.py
@@ -23,6 +23,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+if str(Path(__file__).resolve().parent) not in sys.path:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from compare_coverage import compare_coverage_files
+
 ROOT = Path(__file__).resolve().parent.parent
 BENCHMARKS_DIR = ROOT / "benchmarks"
 RUNS_DIR = ROOT / "runs"
@@ -246,11 +251,32 @@ def previous_best_summary(*, current_run_id: str) -> dict[str, Any] | None:
     return max(candidates, key=lambda item: float(item.get("mean_composite", 0.0)))
 
 
+def coverage_path_for_run(run_id: str) -> Path:
+    return RUNS_DIR / run_id / "coverage.json"
+
+
+def load_coverage_diff(*, current_run_id: str, baseline_summary: dict[str, Any] | None) -> dict[str, Any] | None:
+    if baseline_summary is None:
+        return None
+
+    baseline_run_id = baseline_summary.get("run_id")
+    if not isinstance(baseline_run_id, str) or not baseline_run_id:
+        return None
+
+    before_path = coverage_path_for_run(baseline_run_id)
+    after_path = coverage_path_for_run(current_run_id)
+    if not before_path.exists() or not after_path.exists():
+        return None
+
+    return compare_coverage_files(before_path=before_path, after_path=after_path)
+
+
 def evaluate_reject_reasons(
     results: list[dict[str, Any]],
     *,
     current_mean_composite: float,
     baseline_summary: dict[str, Any] | None,
+    coverage_diff: dict[str, Any] | None = None,
 ) -> list[str]:
     if baseline_summary is None:
         return []
@@ -288,6 +314,18 @@ def evaluate_reject_reasons(
                 f"{benchmark_name}: review_quality regressed from {baseline_quality:.3f} to {current_quality:.3f}"
             )
 
+    regressions = coverage_diff.get("regressions", []) if isinstance(coverage_diff, dict) else []
+    if regressions:
+        regressed_slugs = ", ".join(
+            sorted(
+                str(regression["slug"])
+                for regression in regressions
+                if isinstance(regression, dict) and isinstance(regression.get("slug"), str)
+            )
+        )
+        if regressed_slugs:
+            reject_reasons.append(f"layout regressions: {regressed_slugs}")
+
     return reject_reasons
 
 
@@ -295,10 +333,12 @@ def build_summary(*, run_id: str, results: list[dict[str, Any]]) -> dict[str, An
     composites = [r["scores"]["composite"] for r in results if "composite" in r["scores"]]
     mean_composite = round(sum(composites) / len(composites), 1) if composites else 0.0
     baseline_summary = previous_best_summary(current_run_id=run_id)
+    coverage_diff = load_coverage_diff(current_run_id=run_id, baseline_summary=baseline_summary)
     reject_reasons = evaluate_reject_reasons(
         results,
         current_mean_composite=mean_composite,
         baseline_summary=baseline_summary,
+        coverage_diff=coverage_diff,
     )
     review_unavailable = [
         result["benchmark"]
@@ -317,6 +357,8 @@ def build_summary(*, run_id: str, results: list[dict[str, Any]]) -> dict[str, An
     if baseline_summary is not None:
         summary["previous_best_run_id"] = baseline_summary.get("run_id")
         summary["previous_best_mean_composite"] = baseline_summary.get("mean_composite")
+    if coverage_diff is not None:
+        summary["coverage_diff"] = coverage_diff
     return summary
 
 

--- a/tests/test_compare_coverage.py
+++ b/tests/test_compare_coverage.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT / "scripts" / "compare_coverage.py"
+
+
+def _load_script_module():
+    spec = importlib.util.spec_from_file_location("compare_coverage", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _run_script(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write_coverage(path: Path, *, template: str, layouts: list[dict[str, object]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"template": template, "layouts": layouts}, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def test_compare_coverage_detects_regressions_improvements_and_new_layouts(tmp_path: Path) -> None:
+    module = _load_script_module()
+    before_path = tmp_path / "before.json"
+    after_path = tmp_path / "after.json"
+    _write_coverage(
+        before_path,
+        template="bcg",
+        layouts=[
+            {"slug": "title_only", "variants_passed": 2},
+            {"slug": "image_left", "variants_passed": 0},
+            {"slug": "quote", "variants_passed": 1},
+            {"slug": "gallery", "variants_passed": 0},
+        ],
+    )
+    _write_coverage(
+        after_path,
+        template="bcg",
+        layouts=[
+            {"slug": "title_only", "variants_passed": 0},
+            {"slug": "image_left", "variants_passed": 1},
+            {"slug": "quote", "variants_passed": 3},
+            {"slug": "hero_image", "variants_passed": 1},
+        ],
+    )
+
+    diff = module.compare_coverage_files(before_path=before_path, after_path=after_path)
+
+    assert diff["regressions"] == [{"slug": "title_only", "before_passed": 2, "after_passed": 0}]
+    assert diff["improvements"] == [{"slug": "image_left", "before_passed": 0, "after_passed": 1}]
+    assert diff["new_layouts"] == [{"slug": "hero_image", "before_passed": 0, "after_passed": 1}]
+    assert diff["unchanged"] == [
+        {"slug": "gallery", "before_passed": 0, "after_passed": 0},
+        {"slug": "quote", "before_passed": 1, "after_passed": 3},
+    ]
+
+
+def test_compare_coverage_script_exit_code_reflects_regressions(tmp_path: Path) -> None:
+    before_path = tmp_path / "before.json"
+    after_path = tmp_path / "after.json"
+    _write_coverage(
+        before_path,
+        template="bcg",
+        layouts=[{"slug": "title_only", "variants_passed": 1}],
+    )
+    _write_coverage(
+        after_path,
+        template="bcg",
+        layouts=[{"slug": "title_only", "variants_passed": 0}],
+    )
+
+    result = _run_script("--before", str(before_path), "--after", str(after_path))
+
+    assert result.returncode == 1
+    payload = json.loads(result.stdout)
+    assert payload["regressions"] == [{"slug": "title_only", "before_passed": 1, "after_passed": 0}]
+
+
+def test_compare_coverage_script_exits_zero_without_regressions(tmp_path: Path) -> None:
+    before_path = tmp_path / "before.json"
+    after_path = tmp_path / "after.json"
+    _write_coverage(
+        before_path,
+        template="bcg",
+        layouts=[{"slug": "title_only", "variants_passed": 0}],
+    )
+    _write_coverage(
+        after_path,
+        template="bcg",
+        layouts=[
+            {"slug": "title_only", "variants_passed": 1},
+            {"slug": "hero_image", "variants_passed": 1},
+        ],
+    )
+
+    result = _run_script("--before", str(before_path), "--after", str(after_path))
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["regressions"] == []
+    assert payload["improvements"] == [{"slug": "title_only", "before_passed": 0, "after_passed": 1}]
+    assert payload["new_layouts"] == [{"slug": "hero_image", "before_passed": 0, "after_passed": 1}]

--- a/tests/test_demo_research.py
+++ b/tests/test_demo_research.py
@@ -577,3 +577,98 @@ def test_build_summary_rejects_composite_regression_even_when_review_improves(mo
 
     assert summary["decision"] == "reject"
     assert summary["reject_reasons"] == ["composite regressed from 81.0 to 79.0"]
+
+
+def test_build_summary_rejects_layout_regressions_from_previous_best_coverage(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_script_module()
+    runs_dir = tmp_path / "runs"
+    previous = {
+        "run_id": "baseline",
+        "mean_composite": 75.0,
+        "benchmarks": [
+            {"benchmark": "alpha", "scores": {"composite": 75.0, "review_available": True, "review_quality": 0.9}}
+        ],
+    }
+    results = [
+        {"benchmark": "alpha", "scores": {"composite": 80.0, "review_available": True, "review_quality": 0.92}}
+    ]
+    (runs_dir / "baseline").mkdir(parents=True)
+    (runs_dir / "candidate").mkdir(parents=True)
+    (runs_dir / "baseline" / "coverage.json").write_text(
+        json.dumps(
+            {
+                "template": "bcg",
+                "layouts": [
+                    {"slug": "hero_image", "variants_passed": 1},
+                    {"slug": "title_only", "variants_passed": 0},
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    (runs_dir / "candidate" / "coverage.json").write_text(
+        json.dumps(
+            {
+                "template": "bcg",
+                "layouts": [
+                    {"slug": "hero_image", "variants_passed": 0},
+                    {"slug": "title_only", "variants_passed": 1},
+                ],
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "RUNS_DIR", runs_dir)
+    monkeypatch.setattr(module, "previous_best_summary", lambda current_run_id: previous)
+
+    summary = module.build_summary(run_id="candidate", results=results)
+
+    assert summary["decision"] == "reject"
+    assert "layout regressions: hero_image" in summary["reject_reasons"]
+    assert summary["coverage_diff"]["regressions"] == [
+        {"slug": "hero_image", "before_passed": 1, "after_passed": 0}
+    ]
+
+
+def test_build_summary_skips_layout_regression_gate_without_previous_coverage(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    module = _load_script_module()
+    runs_dir = tmp_path / "runs"
+    previous = {
+        "run_id": "baseline",
+        "mean_composite": 75.0,
+        "benchmarks": [
+            {"benchmark": "alpha", "scores": {"composite": 75.0, "review_available": True, "review_quality": 0.9}}
+        ],
+    }
+    results = [
+        {"benchmark": "alpha", "scores": {"composite": 80.0, "review_available": True, "review_quality": 0.92}}
+    ]
+    (runs_dir / "candidate").mkdir(parents=True)
+    (runs_dir / "candidate" / "coverage.json").write_text(
+        json.dumps(
+            {"template": "bcg", "layouts": [{"slug": "hero_image", "variants_passed": 0}]},
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(module, "RUNS_DIR", runs_dir)
+    monkeypatch.setattr(module, "previous_best_summary", lambda current_run_id: previous)
+
+    summary = module.build_summary(run_id="candidate", results=results)
+
+    assert summary["decision"] == "accept"
+    assert summary["reject_reasons"] == []
+    assert "coverage_diff" not in summary


### PR DESCRIPTION
## Summary
- add `scripts/compare_coverage.py` to diff coverage runs and fail on per-layout regressions
- reject demo research runs when the previous best coverage loses any previously passing layout
- document the new gate and cover it with targeted tests

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run ruff check scripts/`
- `UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run pytest -q tests/test_compare_coverage.py`
- `UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run ruff check scripts/ tests/`
- `UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run pytest -q tests/test_compare_coverage.py tests/test_demo_research.py`
- `UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run pytest -v`
- synthetic CLI proof: `UV_CACHE_DIR=/tmp/uv-cache XDG_CACHE_HOME=/tmp/xdg-cache uv run python scripts/compare_coverage.py --before <tmp>/before.json --after <tmp>/after.json`

Closes #235