### PR TITLE
Add virtual body slots for heading-only template layouts

### DIFF
--- a/scripts/export_layout_inventory.py
+++ b/scripts/export_layout_inventory.py
@@ -8,6 +8,9 @@ import sys
 from pathlib import Path
 from typing import Any
 
+from agent_slides.model.types import STANDARD_SLIDE_HEIGHT_PT, STANDARD_SLIDE_WIDTH_PT
+from agent_slides.template_slots import infer_template_slot_role
+
 try:
     import yaml
 except ImportError:  # pragma: no cover - PyYAML is a project dependency.
@@ -280,6 +283,83 @@ def _resolve_slot_bounds(
     )
 
 
+def _resolve_slot_mapping(
+    slot_name: str,
+    raw_slot: object,
+    *,
+    placeholders_by_idx: dict[int, dict[str, float]],
+) -> dict[str, Any]:
+    if isinstance(raw_slot, bool):
+        raise ValueError(f"slot_mapping[{slot_name!r}] must not be a boolean")
+    if isinstance(raw_slot, int):
+        try:
+            return dict(placeholders_by_idx[raw_slot])
+        except KeyError as exc:
+            raise ValueError(
+                f"slot_mapping[{slot_name!r}] references missing placeholder idx {raw_slot}"
+            ) from exc
+    if not isinstance(raw_slot, dict):
+        raise ValueError(f"slot_mapping[{slot_name!r}] must be an integer or object")
+    return dict(raw_slot)
+
+
+def _theme_spacing(manifest: dict[str, Any]) -> tuple[float, float]:
+    theme = manifest.get("theme", {})
+    if not isinstance(theme, dict):
+        return (48.0, 18.0)
+    spacing = theme.get("spacing", {})
+    if not isinstance(spacing, dict):
+        return (48.0, 18.0)
+
+    margin = spacing.get("margin", 48.0)
+    gutter = spacing.get("gutter", 18.0)
+    if isinstance(margin, bool) or not isinstance(margin, int | float):
+        margin = 48.0
+    if isinstance(gutter, bool) or not isinstance(gutter, int | float):
+        gutter = 18.0
+    return (float(margin), float(gutter))
+
+
+def _virtual_body_bounds(
+    layout: dict[str, Any],
+    *,
+    manifest: dict[str, Any],
+    placeholders_by_idx: dict[int, dict[str, float]],
+) -> dict[str, float] | None:
+    slot_mapping = layout.get("slot_mapping", {})
+    if not isinstance(slot_mapping, dict):
+        raise ValueError(
+            f"Layout '{layout.get('slug', '<unknown>')}' slot_mapping must be an object"
+        )
+    if "heading" not in slot_mapping or "body" in slot_mapping:
+        return None
+
+    for slot_name, raw_slot in slot_mapping.items():
+        if slot_name == "heading":
+            continue
+        resolved_slot = _resolve_slot_mapping(
+            slot_name,
+            raw_slot,
+            placeholders_by_idx=placeholders_by_idx,
+        )
+        if infer_template_slot_role(slot_name, resolved_slot) == "body":
+            return None
+
+    heading_bounds = _resolve_slot_bounds(
+        "heading",
+        slot_mapping["heading"],
+        placeholders_by_idx=placeholders_by_idx,
+    )
+    margin, gutter = _theme_spacing(manifest)
+    left = max(heading_bounds["x"], margin)
+    top = heading_bounds["y"] + heading_bounds["h"] + gutter
+    right = STANDARD_SLIDE_WIDTH_PT - margin
+    bottom = STANDARD_SLIDE_HEIGHT_PT - margin
+    if top >= bottom or left >= right:
+        return None
+    return {"x": left, "y": top, "w": right - left, "h": bottom - top}
+
+
 def _classify_slot_structure(fillable_slots: list[str]) -> str:
     slot_names = set(fillable_slots)
     if not slot_names:
@@ -329,10 +409,8 @@ def build_inventory(
         if not isinstance(slot_mapping, dict):
             raise ValueError(f"Layout '{slug}' slot_mapping must be an object")
 
-        fillable_slots = sorted(
-            (str(slot_name) for slot_name in slot_mapping), key=_slot_sort_key
-        )
         placeholder_idx_map = _placeholders_by_idx(layout)
+        fillable_slots = {str(slot_name) for slot_name in slot_mapping}
         placeholder_bounds = {
             slot_name: _resolve_slot_bounds(
                 slot_name,
@@ -341,6 +419,15 @@ def build_inventory(
             )
             for slot_name in fillable_slots
         }
+        virtual_body = _virtual_body_bounds(
+            layout,
+            manifest=manifest,
+            placeholders_by_idx=placeholder_idx_map,
+        )
+        if virtual_body is not None:
+            fillable_slots.add("body")
+            placeholder_bounds["body"] = virtual_body
+        ordered_fillable_slots = sorted(fillable_slots, key=_slot_sort_key)
         usable = bool(layout.get("usable", bool(fillable_slots)))
         exclude_reason = policy.get(slug)
         is_disclaimer_duplicate = slug.startswith("d_")
@@ -350,8 +437,8 @@ def build_inventory(
             "usable": usable,
             "requires_image": "image" in slot_mapping,
             "is_disclaimer_duplicate": is_disclaimer_duplicate,
-            "slot_structure": _classify_slot_structure(fillable_slots),
-            "fillable_slots": fillable_slots,
+            "slot_structure": _classify_slot_structure(ordered_fillable_slots),
+            "fillable_slots": ordered_fillable_slots,
             "placeholder_bounds": placeholder_bounds,
             "testable": _is_testable(
                 usable=usable,

--- a/skills/create-deck/SKILL.md
+++ b/skills/create-deck/SKILL.md
@@ -327,6 +327,7 @@ Before QA, read `${CLAUDE_SKILL_DIR}/references/common-mistakes.md`.
 3. Fix any issues.
 4. Run `uv run agent-slides validate deck.json` again.
 5. Only then build the `.pptx`.
+6. When the user wants live review, run `uv run agent-slides preview deck.json --background` and open that URL for the user immediately.
 
 If validation passes but the storytelling checklist fails, the deck is not done.
 

--- a/src/agent_slides/io/pptx_writer.py
+++ b/src/agent_slides/io/pptx_writer.py
@@ -791,13 +791,13 @@ def _fill_placeholder(
     *,
     computed: ComputedNode | None = None,
     conditional_formatting: ConditionalFormatting | None = None,
-) -> None:
+) -> bool:
     if node.slot_binding is None or node.type != "text":
-        return
+        return False
 
     placeholder_idx = binding.slot_mapping.get(node.slot_binding)
     if placeholder_idx is None:
-        return
+        return False
 
     target = binding.placeholders_by_idx.get(
         placeholder_idx, {"idx": placeholder_idx, "type": "BODY"}
@@ -808,7 +808,7 @@ def _fill_placeholder(
         _saved_pPr = None
     elif target_type == "GROUP":
         # Group shapes cannot be filled with text; skip silently.
-        return
+        return True
     else:
         placeholder = slide.placeholders[placeholder_idx]
         text_frame = placeholder.text_frame
@@ -871,6 +871,7 @@ def _fill_placeholder(
                 if position is not None
                 else None,
             )
+    return True
 
 
 def _text_box_frame_for_slot(slide, target: dict[str, Any]):
@@ -932,18 +933,30 @@ def _write_template_pptx(
                     else:
                         _render_pattern_node(pptx_slide.shapes, computed)
         for node in slide.nodes:
+            computed = slide.computed.get(node.node_id)
             if node.type == "icon":
-                computed = slide.computed.get(node.node_id)
                 if computed is not None:
                     _render_icon_node(pptx_slide.shapes, node, computed)
                 continue
-            _fill_placeholder(
+            handled_text = _fill_placeholder(
                 node,
                 binding,
                 pptx_slide,
-                computed=slide.computed.get(node.node_id),
+                computed=computed,
                 conditional_formatting=conditional_formatting,
             )
+            if (
+                not handled_text
+                and node.type == "text"
+                and node.slot_binding is not None
+                and computed is not None
+            ):
+                _render_text_node(
+                    pptx_slide.shapes,
+                    node,
+                    computed,
+                    conditional_formatting=conditional_formatting,
+                )
             _fill_image_placeholder(
                 node,
                 binding.slot_mapping,

--- a/src/agent_slides/model/template_layouts.py
+++ b/src/agent_slides/model/template_layouts.py
@@ -17,6 +17,8 @@ from agent_slides.model.types import (
     GridDef,
     LayoutDef,
     SlotDef,
+    STANDARD_SLIDE_HEIGHT_PT,
+    STANDARD_SLIDE_WIDTH_PT,
     TextFitting,
     Theme,
     ThemeColors,
@@ -397,6 +399,87 @@ def _coerce_placeholder_index(
     return placeholders
 
 
+def _build_virtual_body_slot(
+    slot_mapping: dict[str, Any],
+    *,
+    placeholders_by_idx: dict[int, dict[str, Any]],
+    theme: Theme,
+) -> dict[str, Any] | None:
+    if "heading" not in slot_mapping or "body" in slot_mapping:
+        return None
+    for slot_name, raw_slot in slot_mapping.items():
+        if slot_name == "heading":
+            continue
+        resolved_slot = _coerce_slot_mapping(
+            slot_name,
+            raw_slot,
+            placeholders_by_idx=placeholders_by_idx,
+        )
+        if _infer_role(slot_name, resolved_slot) == "body":
+            return None
+
+    heading_mapping = _coerce_slot_mapping(
+        "heading",
+        slot_mapping["heading"],
+        placeholders_by_idx=placeholders_by_idx,
+    )
+    heading_bounds = _as_dict(
+        heading_mapping.get("bounds", heading_mapping),
+        context="slot_mapping['heading'] bounds",
+    )
+    heading_x = _optional_number(heading_bounds, "x", "left")
+    heading_y = _optional_number(heading_bounds, "y", "top")
+    heading_height = _optional_number(heading_bounds, "height", "h")
+    if heading_x is None or heading_y is None or heading_height is None:
+        return None
+
+    margin = float(theme.spacing.margin)
+    gutter = float(theme.spacing.gutter)
+    left = max(float(heading_x), margin)
+    top = float(heading_y) + float(heading_height) + gutter
+    right = STANDARD_SLIDE_WIDTH_PT - margin
+    bottom = STANDARD_SLIDE_HEIGHT_PT - margin
+    if top >= bottom or left >= right:
+        return None
+
+    return {
+        "role": "body",
+        "virtual": True,
+        "bounds": {
+            "x": left,
+            "y": top,
+            "width": right - left,
+            "height": bottom - top,
+        },
+    }
+
+
+def _augment_virtual_slots(
+    slot_mapping: dict[str, Any],
+    *,
+    placeholders_by_idx: dict[int, dict[str, Any]],
+    theme: Theme,
+) -> dict[str, Any]:
+    virtual_body = _build_virtual_body_slot(
+        slot_mapping,
+        placeholders_by_idx=placeholders_by_idx,
+        theme=theme,
+    )
+    if virtual_body is None:
+        return slot_mapping
+
+    augmented: dict[str, Any] = {}
+    inserted = False
+    for slot_name, slot_value in slot_mapping.items():
+        augmented[slot_name] = slot_value
+        if slot_name == "heading":
+            augmented["body"] = virtual_body
+            inserted = True
+    if not inserted:
+        augmented["body"] = virtual_body
+    return augmented
+
+
 def _reading_order(slots: dict[str, SlotDef]) -> list[tuple[str, SlotDef]]:
     return sorted(
         slots.items(),
@@ -771,6 +854,11 @@ class TemplateLayoutRegistry:
             )
             slot_mapping = normalize_template_slot_mapping(
                 slot_mapping, placeholders_by_idx=placeholders_by_idx
+            )
+            slot_mapping = _augment_virtual_slots(
+                slot_mapping,
+                placeholders_by_idx=placeholders_by_idx,
+                theme=self._theme,
             )
             master_index = raw_layout.get("master_index", 0)
             layout_index = raw_layout.get("index", 0)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -71,6 +71,43 @@ def write_deck(path: Path, deck: Deck) -> None:
     write_computed_deck(str(path), deck)
 
 
+def write_heading_only_template_manifest(path: Path, template_path: Path) -> None:
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_bytes(b"pptx")
+    write_json(
+        path,
+        {
+            "source": template_path.name,
+            "source_hash": "abc123",
+            "theme": {
+                "colors": {
+                    "primary": "#112233",
+                    "secondary": "#223344",
+                    "accent": "#445566",
+                    "background": "#FAFAFA",
+                    "text": "#101010",
+                    "heading_text": "#202020",
+                    "subtle_text": "#606060",
+                },
+                "fonts": {"heading": "Aptos Display", "body": "Aptos"},
+                "spacing": {"base_unit": 10, "margin": 48, "gutter": 18},
+            },
+            "layouts": [
+                {
+                    "slug": "green_highlight",
+                    "usable": True,
+                    "slot_mapping": {
+                        "heading": {
+                            "role": "heading",
+                            "bounds": {"x": 72, "y": 64, "width": 560, "height": 72},
+                        }
+                    },
+                }
+            ],
+        },
+    )
+
+
 def build_slide(
     slide_id: str, layout: str, slots: list[str], *, start_node: int = 1
 ) -> Slide:
@@ -523,6 +560,64 @@ def test_init_with_template_sets_relative_manifest_and_uses_manifest_layouts(
             "message": "Unknown layout 'two_col'. Available layouts: title_slide, two_content",
         },
     }
+
+
+def test_slot_set_accepts_virtual_body_slot_for_heading_only_template_layouts(
+    tmp_path: Path,
+) -> None:
+    deck_path = tmp_path / "decks" / "deck.json"
+    manifest_path = tmp_path / "templates" / "heading-only.manifest.json"
+    template_path = tmp_path / "templates" / "heading-only.pptx"
+    deck_path.parent.mkdir(parents=True)
+    manifest_path.parent.mkdir(parents=True)
+    write_heading_only_template_manifest(manifest_path, template_path)
+
+    init_result = invoke_cli(["init", str(deck_path), "--template", str(manifest_path)])
+    assert init_result.exit_code == 0
+
+    slide_add = invoke_cli(["slide", "add", str(deck_path), "--layout", "green_highlight"])
+    assert slide_add.exit_code == 0
+
+    heading_result = invoke_cli(
+        [
+            "slot",
+            "set",
+            str(deck_path),
+            "--slide",
+            "0",
+            "--slot",
+            "heading",
+            "--text",
+            "Heading",
+        ]
+    )
+    body_result = invoke_cli(
+        [
+            "slot",
+            "set",
+            str(deck_path),
+            "--slide",
+            "0",
+            "--slot",
+            "body",
+            "--text",
+            "Bullet copy",
+        ]
+    )
+
+    assert heading_result.exit_code == 0
+    assert body_result.exit_code == 0
+
+    deck = read_deck(str(deck_path))
+    slide = deck.slides[0]
+    assert {node.slot_binding for node in slide.nodes} == {"heading", "body"}
+    assert slide.computed
+    assert slide.computed[next(node.node_id for node in slide.nodes if node.slot_binding == "body")].y == pytest.approx(154.0)
+
+    validate_result = invoke_cli(["validate", str(deck_path)])
+    assert validate_result.exit_code == 0
+    validate_payload = json.loads(validate_result.output)
+    assert validate_payload["ok"] is True
 
 
 def test_init_returns_error_when_theme_and_template_are_both_provided(

--- a/tests/test_export_layout_inventory.py
+++ b/tests/test_export_layout_inventory.py
@@ -266,7 +266,7 @@ def test_export_layout_inventory_cli_outputs_expected_inventory(tmp_path: Path) 
 
     assert layouts["title_only"]["slot_structure"] == "heading_only"
     assert layouts["body_text"]["slot_structure"] == "heading_body"
-    assert layouts["visual_story"]["slot_structure"] == "heading_image"
+    assert layouts["visual_story"]["slot_structure"] == "heading_body_image"
     assert layouts["mixed_story"]["slot_structure"] == "heading_body_image"
     assert layouts["three_up"]["slot_structure"] == "multi_slot"
     assert layouts["blankish"]["slot_structure"] == "blank"
@@ -285,6 +285,7 @@ def test_export_layout_inventory_cli_outputs_expected_inventory(tmp_path: Path) 
         "body": {"x": 60.0, "y": 140.0, "w": 520.0, "h": 240.0},
     }
     assert layouts["mixed_story"]["fillable_slots"] == ["heading", "body", "image"]
+    assert layouts["visual_story"]["fillable_slots"] == ["heading", "body", "image"]
 
 
 def test_export_layout_inventory_treats_all_usable_layouts_as_testable_without_matching_policy(

--- a/tests/test_pptx_writer.py
+++ b/tests/test_pptx_writer.py
@@ -1838,6 +1838,97 @@ def test_write_pptx_fills_non_placeholder_text_box_slots_in_template_clone_path(
     assert quote_shape.height == int(120.0 * EMU_PER_POINT)
 
 
+def test_write_pptx_renders_virtual_body_slots_as_positioned_text_boxes(
+    tmp_path: Path,
+) -> None:
+    _, manifest_path, manifest = create_template_manifest(tmp_path)
+    output_path = tmp_path / "template-virtual-body-output.pptx"
+    title_layout = find_layout(manifest, {"heading", "subheading"})
+
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    payload["slide_masters"][0]["layouts"] = [
+        {
+            "index": title_layout["index"],
+            "master_index": title_layout["master_index"],
+            "name": title_layout["name"],
+            "slug": "green_highlight",
+            "usable": True,
+            "placeholders": title_layout["placeholders"],
+            "slot_mapping": {"heading": title_layout["slot_mapping"]["heading"]},
+        }
+    ]
+    manifest_path.write_text(f"{json.dumps(payload, indent=2)}\n", encoding="utf-8")
+
+    deck = Deck(
+        deck_id="template-virtual-body",
+        template_manifest=str(manifest_path),
+        slides=[
+            Slide(
+                slide_id="s-1",
+                layout="green_highlight",
+                nodes=[
+                    Node(
+                        node_id="n-1",
+                        slot_binding="heading",
+                        type="text",
+                        content="Updated title",
+                    ),
+                    Node(
+                        node_id="n-2",
+                        slot_binding="body",
+                        type="text",
+                        content="Body content in virtual slot",
+                    ),
+                ],
+                computed={
+                    "n-1": ComputedNode(
+                        x=72.0,
+                        y=36.0,
+                        width=576.0,
+                        height=72.0,
+                        font_size_pt=28.0,
+                        font_family="Aptos",
+                        color="#112233",
+                        bg_color=None,
+                        font_bold=True,
+                        revision=1,
+                    ),
+                    "n-2": ComputedNode(
+                        x=72.0,
+                        y=154.0,
+                        width=576.0,
+                        height=220.0,
+                        font_size_pt=18.0,
+                        font_family="Aptos",
+                        color="#445566",
+                        bg_color=None,
+                        font_bold=False,
+                        revision=1,
+                    ),
+                },
+            )
+        ],
+        counters=Counters(slides=1, nodes=2),
+    )
+
+    write_pptx(deck, str(output_path))
+
+    presentation = open_presentation(output_path)
+    slide = presentation.slides[0]
+    body_shape = next(
+        shape
+        for shape in slide.shapes
+        if shape.has_text_frame and shape.text_frame.text == "Body content in virtual slot"
+    )
+
+    assert slide.slide_layout.name == title_layout["name"]
+    assert body_shape.is_placeholder is False
+    assert body_shape.left == int(72.0 * EMU_PER_POINT)
+    assert body_shape.top == int(154.0 * EMU_PER_POINT)
+    assert body_shape.width == int(576.0 * EMU_PER_POINT)
+    assert body_shape.height == int(220.0 * EMU_PER_POINT)
+
+
 def test_write_pptx_warns_when_template_hash_changes(
     tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:

--- a/tests/test_template_layouts.py
+++ b/tests/test_template_layouts.py
@@ -101,6 +101,63 @@ def _build_manifest(base_dir: Path) -> Path:
     return manifest_path
 
 
+def _build_heading_only_manifest(base_dir: Path) -> Path:
+    template_path = base_dir / "templates" / "heading-only" / "template.pptx"
+    manifest_path = base_dir / "templates" / "heading-only" / "manifest.json"
+    template_path.parent.mkdir(parents=True, exist_ok=True)
+    template_path.write_bytes(b"pptx")
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "name": "heading-only-template",
+                "source": "template.pptx",
+                "source_hash": "heading123",
+                "theme": {
+                    "name": "heading-only-theme",
+                    "colors": {
+                        "primary": "#101820",
+                        "secondary": "#203040",
+                        "accent": "#ff6600",
+                        "background": "#faf7f2",
+                        "text": "#1f1f1f",
+                        "heading_text": "#111111",
+                        "subtle_text": "#666666",
+                    },
+                    "fonts": {
+                        "heading": "Aptos Display",
+                        "body": "Aptos",
+                    },
+                    "spacing": {
+                        "base_unit": 12,
+                        "margin": 48,
+                        "gutter": 18,
+                    },
+                },
+                "layouts": [
+                    {
+                        "slug": "green_highlight",
+                        "usable": True,
+                        "slot_mapping": {
+                            "heading": {
+                                "role": "heading",
+                                "bounds": {
+                                    "x": 72,
+                                    "y": 64,
+                                    "width": 560,
+                                    "height": 72,
+                                },
+                            }
+                        },
+                    }
+                ],
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
 def _build_template_deck(manifest_relpath: str) -> Deck:
     return Deck(
         deck_id="deck-template",
@@ -256,6 +313,24 @@ def test_template_layout_registry_uses_default_text_fitting(tmp_path: Path) -> N
     assert heading_fit.min_size == 24.0
     assert body_fit.default_size == 18.0
     assert body_fit.min_size == 10.0
+
+
+def test_template_layout_registry_synthesizes_virtual_body_slot_for_heading_only_layout(
+    tmp_path: Path,
+) -> None:
+    manifest_path = _build_heading_only_manifest(tmp_path)
+
+    registry = TemplateLayoutRegistry(str(manifest_path))
+    layout = registry.get_layout("green_highlight")
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+
+    assert registry.get_slot_names("green_highlight") == ["heading", "body"]
+    assert "body" not in manifest["layouts"][0]["slot_mapping"]
+    assert layout.slots["body"].role == "body"
+    assert layout.slots["body"].x == 72.0
+    assert layout.slots["body"].y == 154.0
+    assert layout.slots["body"].width == 600.0
+    assert layout.slots["body"].height == 338.0
 
 
 def test_template_layout_registry_infers_slot_metadata_from_placeholder_topology(

--- a/tests/test_template_reflow.py
+++ b/tests/test_template_reflow.py
@@ -84,6 +84,51 @@ def make_manifest() -> dict[str, object]:
     }
 
 
+def make_heading_only_manifest() -> dict[str, object]:
+    return {
+        "name": "template",
+        "source": "template.pptx",
+        "source_hash": "abc123",
+        "layouts": [
+            {
+                "slug": "green_highlight",
+                "usable": True,
+                "slot_mapping": {
+                    "heading": {
+                        "role": "heading",
+                        "bounds": {
+                            "x": 72.0,
+                            "y": 64.0,
+                            "width": 560.0,
+                            "height": 72.0,
+                        },
+                    }
+                },
+            }
+        ],
+        "theme": {
+            "colors": {
+                "primary": "#112233",
+                "secondary": "#445566",
+                "accent": "#778899",
+                "text": "#101010",
+                "heading_text": "#202020",
+                "subtle_text": "#606060",
+                "background": "#FAFAFA",
+            },
+            "fonts": {
+                "heading": "Aptos Display",
+                "body": "Aptos",
+            },
+            "spacing": {
+                "base_unit": 10.0,
+                "margin": 48.0,
+                "gutter": 18.0,
+            },
+        },
+    }
+
+
 def test_reflow_deck_uses_manifest_bounds_theme_and_text_fitting(
     tmp_path: Path, monkeypatch
 ) -> None:
@@ -263,3 +308,81 @@ def test_mutate_deck_reflows_template_manifests_with_unified_reflow(
     assert updated_deck.revision == 3
     assert updated_deck.theme == "corporate"
     assert reflow_calls == [(3, str((tmp_path / "template.pptx").resolve()))]
+
+
+def test_reflow_deck_uses_virtual_body_slot_bounds_for_heading_only_templates(
+    tmp_path: Path, monkeypatch
+) -> None:
+    manifest_path = tmp_path / "template.manifest.json"
+    (tmp_path / "template.pptx").write_bytes(b"pptx")
+    write_json(manifest_path, make_heading_only_manifest())
+
+    fit_calls: list[
+        tuple[float, float, float, float, str, str, list[float] | None]
+    ] = []
+
+    def fake_fit_text(
+        *,
+        text,
+        width: float,
+        height: float,
+        default_size: float,
+        min_size: float,
+        role: str,
+        font_family: str | None = None,
+        ladder: list[float] | None = None,
+        use_precise: bool = False,
+    ):
+        assert use_precise is False
+        fit_calls.append(
+            (width, height, default_size, min_size, role, font_family or "", ladder)
+        )
+        return (26.0, False) if role == "heading" else (14.0, False)
+
+    monkeypatch.setattr("agent_slides.engine.reflow.fit_text", fake_fit_text)
+
+    deck = Deck(
+        deck_id="deck-template",
+        revision=7,
+        theme="default",
+        design_rules="default",
+        template_manifest="template.manifest.json",
+        slides=[
+            Slide(
+                slide_id="s-1",
+                layout="green_highlight",
+                nodes=[
+                    Node(
+                        node_id="n-1",
+                        slot_binding="heading",
+                        type="text",
+                        content="Long heading",
+                    ),
+                    Node(
+                        node_id="n-2",
+                        slot_binding="body",
+                        type="text",
+                        content="Long body copy",
+                    ),
+                ],
+            )
+        ],
+        counters=Counters(slides=1, nodes=2),
+    )
+
+    registry = TemplateLayoutRegistry(manifest_path)
+
+    reflow_deck(deck, registry)
+
+    computed = deck.slides[0].computed
+    assert set(computed) == {"n-1", "n-2"}
+
+    body = computed["n-2"]
+    assert (body.x, body.y, body.width, body.height) == (72.0, 154.0, 600.0, 338.0)
+    assert body.font_size_pt == 14.0
+    assert body.font_family == "Aptos"
+    assert body.color == "#101010"
+    assert body.text_overflow is False
+
+    body_call = fit_calls[1]
+    assert body_call[:6] == (600.0, 338.0, 18.0, 10.0, "body", "Aptos")


### PR DESCRIPTION
## Summary
- synthesize a virtual `body` slot for template layouts that have a heading but no body-role slot
- render template text nodes without native placeholder bindings as positioned text boxes in the template writer
- extend CLI, reflow, writer, and inventory coverage for the new template behavior

## Validation
- `UV_CACHE_DIR=/tmp/uv-cache uv run ruff check src/ tests/ scripts/`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -q`
- `UV_CACHE_DIR=/tmp/uv-cache uv run pytest -v`
- direct CLI proof: built `green_highlight` with a virtual body text box and `title_and_text` with the native body placeholder

Closes #249